### PR TITLE
useExperimentalTACKExtension spelling was incorrect

### DIFF
--- a/tests/httpsclient.py
+++ b/tests/httpsclient.py
@@ -3,7 +3,7 @@
 from tlslite import HTTPTLSConnection, HandshakeSettings
 
 settings = HandshakeSettings()
-settings.useExperimentalTACKExtension = True
+settings.useExperimentalTackExtension = True
 
 h = HTTPTLSConnection("localhost", 4443, settings=settings)    
 h.request("GET", "/index.html")


### PR DESCRIPTION
changed to useExperimentalTackExtension
