### PR TITLE
Fix RSAKey.decrypt(): Revert a patch that broke compatibility with previ...

### DIFF
--- a/tlslite/utils/rsakey.py
+++ b/tlslite/utils/rsakey.py
@@ -123,7 +123,7 @@ class RSAKey(object):
         @rtype: bool
         @return: Whether the signature matches the passed-in data.
         """
-        if len(sigBytes) != numBytes(self.n):
+        if len(sigBytes) > numBytes(self.n):
             return False
         paddedBytes = self._addPKCS1Padding(bytes, 1)
         c = bytesToNumber(sigBytes)
@@ -167,7 +167,7 @@ class RSAKey(object):
         """
         if not self.hasPrivateKey():
             raise AssertionError()
-        if len(encBytes) != numBytes(self.n):
+        if len(encBytes) > numBytes(self.n):
             return None
         c = bytesToNumber(encBytes)
         if c >= self.n:


### PR DESCRIPTION
...ous tlslite version

The patch in commit 0b8b2b4122109f22900ec929432308dd685f1d45 introduced a check on the size of encBytes that make the library incompatible (sometimes, in a pseudo random way...) with previous versione where encBytes is not padded:
-        if len(sigBytes) != numBytes(self.n):
-            return False

If a check should exists it should be like this:
-        if len(sigBytes) > numBytes(self.n):
-            return False

We need to retain compatibility with text encrypted with tlslite 0.3.8, and generally I think is a bad idea to break compatibility this way.
