### PR TITLE
ensure all entries in tlslite.utils.cryptomath.sieve are prime

### DIFF
--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -216,7 +216,7 @@ else:
 #Pre-calculate a sieve of the ~100 primes < 1000:
 def makeSieve(n):
     sieve = list(range(n))
-    for count in range(2, int(math.sqrt(n))):
+    for count in range(2, int(math.sqrt(n))+1):
         if sieve[count] == 0:
             continue
         x = sieve[count] * 2


### PR DESCRIPTION
tlslite.utils.cryptomath.sieve is supposed to be all primes below 1000.

Currently, it contains the composite value 961 (31 \* 31), due to an
off-by-one error in the makeSieve function.

I don't think this is a security vulnerability -- it just makes
tlslite's primality test marginally slower than it could be.  But if
someone was using the sieve to do anything else that relies on its
members being prime, they would be surprised to find 961 in there.

This fix corrects the issue.
