### PR TITLE
link tests in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,13 @@ docs:
 
 dist: docs
 	./setup.py sdist
+
+test:
+	cd tests/ && python ./tlstest.py server localhost:4433 . &
+	sleep 1
+	cd tests/ && python ./tlstest.py client localhost:4433 .
+
+test-dev:
+	cd tests/ && PYTHONPATH=.. python ./tlstest.py server localhost:4433 . &
+	sleep 1
+	cd tests/ && PYTHONPATH=.. python ./tlstest.py client localhost:4433 .


### PR DESCRIPTION
since it is easy to run the tests against either installed library or
development code, make the entries in Makefile that make it easy
