### PR TITLE
Parser fix for getFixBytes

### DIFF
--- a/tlslite/utils/codec.py
+++ b/tlslite/utils/codec.py
@@ -42,6 +42,8 @@ class Parser(object):
         return x
 
     def getFixBytes(self, lengthBytes):
+        if self.index + lengthBytes > len(self.bytes):
+            raise SyntaxError()
         bytes = self.bytes[self.index : self.index+lengthBytes]
         self.index += lengthBytes
         return bytes

--- a/unit_tests/test_tlslite_utils_codec.py
+++ b/unit_tests/test_tlslite_utils_codec.py
@@ -143,16 +143,16 @@ class TestParser(unittest.TestCase):
             b'\x00\x00\x00'
             ))
 
-        # XXX doesn't raise exception!
-        self.assertEqual(bytearray(b'\x00\x00\x00'), p.getVarBytes(2))
+        with self.assertRaises(SyntaxError):
+            p.getVarBytes(2)
 
     def test_getFixBytes_with_incorrect_data(self):
         p = Parser(bytearray(
             b'\x00\x04'
             ))
 
-        # XXX doesn't raise exception!
-        self.assertEqual(bytearray(b'\x00\x04'), p.getFixBytes(10))
+        with self.assertRaises(SyntaxError):
+            p.getFixBytes(10)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
`Parser.getFixBytes()` method doesn't raise exception when we ask for reading of more data that there is in buffer.

Fix it so that its behaviour matches `Parser.get()`
