### PR TITLE
Change implementation of extensions in ClientHello to a list

### DIFF
--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -170,3 +170,7 @@ class TLSUnsupportedError(TLSError):
     """The implementation doesn't support the requested (or required)
     capabilities."""
     pass
+
+class TLSInternalError(TLSError):
+    """The internal state of object is unexpected or invalid"""
+    pass

--- a/tlslite/tlsextension.py
+++ b/tlslite/tlsextension.py
@@ -108,6 +108,18 @@ class TLSExtension(object):
             raise SyntaxError()
         return self
 
+    def __eq__(self, that):
+        """ Test if two TLS extensions will result in the same on the wire
+        representation.
+
+        Will return False for every object that's not an extension.
+        """
+        if hasattr(that, 'ext_type') and hasattr(that, 'ext_data'):
+            return self.ext_type == that.ext_type and \
+                    self.ext_data == that.ext_data
+        else:
+            return False
+
 class SNIExtension(TLSExtension):
     """
     Class for handling Server Name Indication (server_name) extension from

--- a/tlslite/tlsextension.py
+++ b/tlslite/tlsextension.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2014, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+""" Helper package for handling TLS extensions encountered in ClientHello
+and ServerHello messages.
+"""
+from __future__ import generators
+from .utils.codec import Writer, Parser
+
+
+class TLSExtension(object):
+    """
+    This class handles the generic information about TLS extensions used by
+    both sides of connection in Client Hello and Server Hello messages.
+    See U{RFC 4366<https://tools.ietf.org/html/rfc4366>} for more info.
+
+    It is used as a base class for specific users and as a way to store
+    extensions that are not implemented in library.
+
+    @type ext_type: int
+    @ivar ext_type: a 2^16-1 limited integer specifying the type of the
+        extension that it contains, e.g. 0 indicates server name extension
+
+    @type ext_data: bytearray
+    @ivar ext_data: a byte array containing the value of the extension as
+        to be written on the wire
+    """
+
+    def __init__(self):
+        """
+        Creates a generic TLS extension that can be used either for
+        client hello or server hello message parsing or creation.
+
+        You'll need to use L{create} or L{parse} methods to create an extension
+        that is actually usable.
+        """
+        self.ext_type = None
+        self.ext_data = bytearray(0)
+
+    def create(self, type, data):
+        """
+        Initializes a generic TLS extension that can later be used in
+        client hello or server hello messages
+
+        @type  type: int
+        @param type: type of the extension encoded as an integer between M{0}
+            and M{2^16-1}
+        @type  data: bytearray
+        @param data: raw data representing extension on the wire
+        @rtype: L{TLSExtension}
+        """
+        self.ext_type = type
+        self.ext_data = data
+        return self
+
+    def write(self):
+        """ Returns encoded extension, as encoded on the wire
+
+        @rtype: bytearray
+        @return: An array of bytes formatted as is supposed to be written on
+           the wire, including the extension_type, length and the extension
+           data
+
+        @raise AssertionError: when the object was not initialized
+        """
+
+        assert self.ext_type is not None
+
+        w = Writer()
+        w.add(self.ext_type, 2)
+        w.add(len(self.ext_data), 2)
+        w.addFixSeq(self.ext_data, 1)
+        return w.bytes
+
+    def parse(self, p):
+        """ Parses extension from the wire format
+
+        @type p: L{tlslite.util.codec.Parser}
+        @param p:  data to be parsed
+
+        @raise SyntaxError: when the size of the passed element doesn't match
+        the internal representation
+
+        @rtype: L{TLSExtension}
+        """
+
+        self.ext_type = p.get(2)
+        ext_length = p.get(2)
+        self.ext_data = p.getFixBytes(ext_length)
+        if len(self.ext_data) != ext_length:
+            raise SyntaxError()
+        return self

--- a/tlslite/tlsextension.py
+++ b/tlslite/tlsextension.py
@@ -301,6 +301,88 @@ class SNIExtension(TLSExtension):
 
         return self
 
+class ClntCertTypeExtension(TLSExtension):
+    """
+    This class handles the Certificate Type extension (variant sent by client)
+    defined in RFC 6091.
+
+    @type ext_type: int
+    @ivar ext_type: numeric type of Certificate Type extension, i.e. 9
+
+    @type ext_data: bytearray
+    @ivar ext_data: raw representation of the extension data
+
+    @type cert_types: list of int
+    @ivar cert_types: list of certificate type identifiers (each one byte long)
+    """
+
+    def __init__(self):
+        """
+        Create an instance of ClntCertTypeExtension
+
+        See also: L{create} and L{parse}
+        """
+
+        self.cert_types = None
+
+    @property
+    def ext_type(self):
+        """
+        Return the type of TLS extension, in this case - 9
+
+        @rtype: int
+        """
+
+        return ExtensionType.cert_type
+
+    @property
+    def ext_data(self):
+        """
+        Return the raw encoding of this extension
+
+        @rtype: bytearray
+        """
+
+        if self.cert_types is None:
+            return bytearray(0)
+
+        w = Writer()
+        w.add(len(self.cert_types), 1)
+        for c_type in self.cert_types:
+            w.add(c_type, 1)
+
+        return w.bytes
+
+    def create(self, cert_types=None):
+        """
+        Return instance of this extension with specified certificate types
+
+        @type cert_types: iterable list of int
+        @param cert_types: list of certificate types to advertise, all values
+            should be between 0 and 2^8-1 inclusive
+
+        @raises ValueError: when the list includes too big or negative integers
+        """
+        self.cert_types = cert_types
+        return self
+
+    def parse(self, p):
+        """
+        Parse the extension from binary data
+
+        @type p: L{tlslite.util.codec.Parser}
+        @param p: data to be parsed
+
+        @raise SyntaxError: when the size of the passed element doesn't match
+            the internal representation
+
+        @rtype: L{ClntCertTypeExtension}
+        """
+
+        self.cert_types = p.getVarList(1, 1)
+
+        return self
+
 class SRPExtension(TLSExtension):
     """
     This class handles the Secure Remote Password protocol TLS extension

--- a/tlslite/tlsextension.py
+++ b/tlslite/tlsextension.py
@@ -5,9 +5,11 @@
 """ Helper package for handling TLS extensions encountered in ClientHello
 and ServerHello messages.
 """
+
 from __future__ import generators
 from .utils.codec import Writer, Parser
-
+from collections import namedtuple
+from .constants import NameType, ExtensionType
 
 class TLSExtension(object):
     """
@@ -91,3 +93,211 @@ class TLSExtension(object):
         if len(self.ext_data) != ext_length:
             raise SyntaxError()
         return self
+
+class SNIExtension(TLSExtension):
+    """
+    Class for handling Server Name Indication (server_name) extension from
+    RFC 4366.
+
+    Note that while usually the client does advertise just one name, it is
+    possible to provide a list of names, each of different type.
+    The type is a single byte value (represented by ints), the names are
+    opaque byte strings, in case of DNS host names (records of type 0) they
+    are UTF-8 encoded domain names (without the ending dot).
+
+    @type host_names: tuple of bytearrays
+    @ivar host_names: tuple of hostnames (server name records of type 0)
+        advertised in the extension. Note that it may not include all names
+        from client hello as the client can advertise other types. Also note
+        that while it's not possible to change the returned array in place, it
+        is possible to assign a new set of names. IOW, this won't work::
+
+           sni_extension.host_names[0] = bytearray(b'example.com')
+
+        while this will work::
+
+           names = list(sni_extension.host_names)
+           names[0] = bytearray(b'example.com')
+           sni_extension.host_names = names
+
+
+    @type server_names: list of L{ServerName}
+    @ivar server_names: list of all names advertised in extension.
+        L{ServerName} is a namedtuple with two elements, the first
+        element (type) defines the type of the name (encoded as int)
+        while the other (name) is a bytearray that carries the value.
+        Known types are defined in L{tlslite.constants.NameType}.
+        The list will be empty if the on the wire extension had and empty
+        list while it will be None if the extension was empty.
+
+    @type ext_type: int
+    @ivar ext_type: numeric type of SNIExtension, i.e. 0
+
+    @type ext_data: bytearray
+    @ivar ext_data: raw representation of the extension
+    """
+
+    ServerName = namedtuple('ServerName', 'type name')
+
+    def __init__(self):
+        """
+        Create an instance of SNIExtension.
+
+        See also: L{create} and L{parse}.
+        """
+        self.server_names = None
+
+    def create(self, hostname=None, host_names=None, server_names=None):
+        """
+        Initializes an instance with provided hostname, host names or
+        raw server names.
+
+        Any of the parameters may be None, in that case the list inside the
+        extension won't be defined, if either host_names or server_names is
+        an empty list, then the extension will define a list of lenght 0.
+
+        If multiple parameters are specified at the same time, then the
+        resulting list of names will be concatenated in order of hostname,
+        host_names and server_names last.
+
+        @type  hostname: bytearray
+        @param hostname: raw UTF-8 encoding of the host name
+
+        @type  host_names: list of bytearrays
+        @param host_names: list of raw UTF-8 encoded host names
+
+        @type  server_names: list of L{ServerName}
+        @param server_names: pairs of type and name
+
+        @rtype: L{SNIExtension}
+        """
+        if hostname is None and host_names is None and server_names is None:
+            self.server_names = None
+            return self
+        else:
+            self.server_names = []
+
+        if hostname:
+            self.server_names+=[SNIExtension.ServerName(NameType.host_name,\
+                    hostname)]
+
+        if host_names:
+            self.server_names+=\
+                    map(lambda x: SNIExtension.ServerName(NameType.host_name,\
+                    x), host_names)
+
+        if server_names:
+            self.server_names+=server_names
+
+        return self
+
+    @property
+    def ext_type(self):
+        """ Return the type of TLS extension, in this case - 0
+
+        @rtype: int
+        """
+        return ExtensionType.server_name
+
+    @property
+    def host_names(self):
+        """ Returns a simulated list of host_names from the extension.
+
+        @rtype: tuple of bytearrays
+        """
+        # because we can't simulate assignments to array elements we return
+        # an immutable type
+        if self.server_names is None:
+            return tuple()
+        else:
+            return tuple([x.name for x in self.server_names if \
+                x.type == NameType.host_name])
+
+    @host_names.setter
+    def host_names(self, host_names):
+        """ Removes all host names from the extension and replaces them by
+        names in X{host_names} parameter.
+
+        Newly added parameters will be added at the I{beginning} of the list
+        of extensions.
+
+        @type host_names: iterable of bytearrays
+        @param host_names: host names to replace the old server names of type 0
+        """
+
+        self.server_names = list(map(\
+                lambda x: SNIExtension.ServerName(NameType.host_name, x),
+                    host_names)) + \
+                [x for x in self.server_names if \
+                    x.type != NameType.host_name]
+
+    @host_names.deleter
+    def host_names(self):
+        """ Remove all host names from extension, leaves other name types
+        unmodified
+        """
+        self.server_names = [x for x in self.server_names if \
+                x.type != NameType.host_name]
+
+    @property
+    def ext_data(self):
+        """ raw encoding of extension data, without type and length header
+
+        @rtype: bytearray
+        """
+        if self.server_names is None:
+            return bytearray(0)
+
+        w2 = Writer()
+        for server_name in self.server_names:
+            w2.add(server_name.type, 1)
+            w2.add(len(server_name.name), 2)
+            w2.bytes += server_name.name
+
+        # note that when the array is empty we write it as array of length 0
+        w = Writer()
+        w.add(len(w2.bytes), 2)
+        w.bytes += w2.bytes
+        return w.bytes
+
+    def write(self):
+        """ Returns encoded extension, as encoded on the wire
+
+        @rtype: bytearray
+        @return: an array of bytes formatted as they are supposed to be written
+            on the wire, including the type, length and extension data
+        """
+
+        raw_data = self.ext_data
+
+        w = Writer()
+        w.add(self.ext_type, 2)
+        w.add(len(raw_data), 2)
+        w.bytes += raw_data
+
+        return w.bytes
+
+    def parse(self, p):
+        """ Parses the on the wire extension data and returns an object that
+        represents it.
+
+        The parser should not include the type or length of extension!
+
+        @type p: L{tlslite.util.codec.Parser}
+        @param p: data to be parsed
+
+        @rtype: L{SNIExtension}
+        @raise SyntaxError: when the internal sizes don't match the attached
+            data
+        """
+        self.server_names = []
+
+        p.startLengthCheck(2)
+        while not p.atLengthCheck():
+            sn_type = p.get(1)
+            sn_name = p.getVarBytes(2)
+            self.server_names += [SNIExtension.ServerName(sn_type, sn_name)]
+        p.stopLengthCheck()
+
+        return self
+

--- a/tlslite/utils/codec.py
+++ b/tlslite/utils/codec.py
@@ -87,3 +87,6 @@ class Parser(object):
             return True
         else:
             raise SyntaxError()
+
+    def getRemainingLength(self):
+        return len(self.bytes) - self.index

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -5,6 +5,8 @@ import unittest
 from tlslite.messages import ClientHello, ServerHello
 from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType
+from tlslite.tlsextension import SNIExtension, ClntCertTypeExtension, \
+    SRPExtension, TLSExtension
 
 class TestClientHello(unittest.TestCase):
     def test___init__(self):
@@ -80,6 +82,7 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual(False, client_hello.supports_npn)
         self.assertEqual(False, client_hello.tack)
         self.assertEqual(None, client_hello.srp_username)
+        self.assertEqual(None, client_hello.extensions)
 
     def test_parse_with_empty_extensions(self):
         p = Parser(bytearray(
@@ -102,6 +105,7 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual(bytearray(0), client_hello.session_id)
         self.assertEqual([], client_hello.cipher_suites)
         self.assertEqual([], client_hello.compression_methods)
+        self.assertEqual([], client_hello.extensions)
 
     def test_parse_with_SNI_extension(self):
         p = Parser(bytearray(
@@ -132,6 +136,8 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual([], client_hello.cipher_suites)
         self.assertEqual([], client_hello.compression_methods)
         self.assertEqual(bytearray(b'example.com'), client_hello.server_name)
+        sni = SNIExtension().create(bytearray(b'example.com'))
+        self.assertEqual([sni], client_hello.extensions)
 
     def test_parse_with_cert_type_extension(self):
         p = Parser(bytearray(
@@ -160,6 +166,8 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual([], client_hello.cipher_suites)
         self.assertEqual([], client_hello.compression_methods)
         self.assertEqual([0,1], client_hello.certificate_types)
+        cert_types = ClntCertTypeExtension().create([0,1])
+        self.assertEqual([cert_types], client_hello.extensions)
 
     def test_parse_with_SRP_extension(self):
         p = Parser(bytearray(
@@ -187,6 +195,8 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual([], client_hello.cipher_suites)
         self.assertEqual([], client_hello.compression_methods)
         self.assertEqual(bytearray(b'username'), client_hello.srp_username)
+        srp = SRPExtension().create(bytearray(b'username'))
+        self.assertEqual([srp], client_hello.extensions)
 
     def test_parse_with_NPN_extension(self):
         p = Parser(bytearray(
@@ -212,6 +222,8 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual([], client_hello.cipher_suites)
         self.assertEqual([], client_hello.compression_methods)
         self.assertEqual(True, client_hello.supports_npn)
+        npn = TLSExtension().create(13172, bytearray(0))
+        self.assertEqual([npn], client_hello.extensions)
 
     def test_parse_with_TACK_extension(self):
         p = Parser(bytearray(
@@ -237,6 +249,8 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual([], client_hello.cipher_suites)
         self.assertEqual([], client_hello.compression_methods)
         self.assertEqual(True, client_hello.tack)
+        tack = TLSExtension().create(62208, bytearray(0))
+        self.assertEqual([tack], client_hello.extensions)
 
     def test_write(self):
         # client_hello = ClientHello(ssl2)

--- a/unit_tests/test_tlslite_tlsextension.py
+++ b/unit_tests/test_tlslite_tlsextension.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2014, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+import unittest
+from tlslite.tlsextension import TLSExtension
+from tlslite.utils.codec import Parser
+
+class TestTLSExtension(unittest.TestCase):
+    def test___init__(self):
+        tls_extension = TLSExtension()
+
+        assert(tls_extension)
+        self.assertIsNone(tls_extension.ext_type)
+        self.assertEqual(bytearray(0), tls_extension.ext_data)
+
+    def test_create(self):
+        tls_extension = TLSExtension().create(1, bytearray(b'\x01\x00'))
+
+        assert tls_extension
+        self.assertEqual(1, tls_extension.ext_type)
+        self.assertEqual(bytearray(b'\x01\x00'), tls_extension.ext_data)
+
+    def test_write(self):
+        tls_extension = TLSExtension()
+
+        with self.assertRaises(AssertionError) as environment:
+            tls_extension.write()
+
+    def test_write_with_data(self):
+        tls_extension = TLSExtension().create(44, bytearray(b'garbage'))
+
+        self.assertEqual(bytearray(
+            b'\x00\x2c' +       # type of extension - 44
+            b'\x00\x07' +       # length of extension - 7 bytes
+            # utf-8 encoding of "garbage"
+            b'\x67\x61\x72\x62\x61\x67\x65'
+            ), tls_extension.write())
+
+    def test_parse(self):
+        p = Parser(bytearray(
+            b'\x00\x42' + # type of extension
+            b'\x00\x01' + # length of rest of data
+            b'\xff'       # value of extension
+            ))
+        tls_extension = TLSExtension().parse(p)
+
+        self.assertEqual(66, tls_extension.ext_type)
+        self.assertEqual(bytearray(b'\xff'), tls_extension.ext_data)
+
+    def test_parse_with_length_long_by_one(self):
+        p = Parser(bytearray(
+            b'\x00\x42' + # type of extension
+            b'\x00\x03' + # length of rest of data
+            b'\xff\xfa'   # value of extension
+            ))
+
+        with self.assertRaises(SyntaxError) as context:
+            TLSExtension().parse(p)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_tlslite_tlsextension.py
+++ b/unit_tests/test_tlslite_tlsextension.py
@@ -74,6 +74,18 @@ class TestTLSExtension(unittest.TestCase):
 
         self.assertEqual(bytearray(b'example.com'), tls_extension.host_names[0])
 
+    def test_equality(self):
+        a = TLSExtension().create(0, bytearray(0))
+        b = SNIExtension().create()
+
+        self.assertTrue(a == b)
+
+    def test_equality_with_empty_array_in_sni_extension(self):
+        a = TLSExtension().create(0, bytearray(b'\x00\x00'))
+        b = SNIExtension().create(server_names=[])
+
+        self.assertTrue(a == b)
+
 class TestSNIExtension(unittest.TestCase):
     def test___init__(self):
         server_name = SNIExtension()

--- a/unit_tests/test_tlslite_tlsextension.py
+++ b/unit_tests/test_tlslite_tlsextension.py
@@ -4,7 +4,7 @@
 
 import unittest
 from tlslite.tlsextension import TLSExtension, SNIExtension, NPNExtension,\
-        SRPExtension
+        SRPExtension, ClntCertTypeExtension
 from tlslite.utils.codec import Parser
 from tlslite.constants import NameType
 
@@ -383,6 +383,73 @@ class TestSNIExtension(unittest.TestCase):
 
         with self.assertRaises(SyntaxError):
             server_name = server_name.parse(p)
+
+class TestClntCertTypeExtension(unittest.TestCase):
+    def test___init___(self):
+        cert_type = ClntCertTypeExtension()
+
+        self.assertEqual(9, cert_type.ext_type)
+        self.assertEqual(bytearray(0), cert_type.ext_data)
+        self.assertEqual(None, cert_type.cert_types)
+
+    def test_create(self):
+        cert_type = ClntCertTypeExtension()
+        cert_type = cert_type.create()
+
+        self.assertEqual(9, cert_type.ext_type)
+        self.assertEqual(bytearray(0), cert_type.ext_data)
+        self.assertEqual(None, cert_type.cert_types)
+
+    def test_create_with_empty_list(self):
+        cert_type = ClntCertTypeExtension()
+        cert_type = cert_type.create([])
+
+        self.assertEqual(bytearray(b'\x00'), cert_type.ext_data)
+        self.assertEqual([], cert_type.cert_types)
+
+    def test_create_with_list(self):
+        cert_type = ClntCertTypeExtension()
+        cert_type = cert_type.create([0])
+
+        self.assertEqual(bytearray(b'\x01\x00'), cert_type.ext_data)
+        self.assertEqual([0], cert_type.cert_types)
+
+    def test_write(self):
+        cert_type = ClntCertTypeExtension()
+        cert_type = cert_type.create([0, 1])
+
+        self.assertEqual(bytearray(
+            b'\x00\x09' +
+            b'\x00\x03' +
+            b'\x02' +
+            b'\x00\x01'), cert_type.write())
+
+    def test_parse(self):
+        cert_type = ClntCertTypeExtension()
+
+        p = Parser(bytearray(b'\x00'))
+
+        cert_type = cert_type.parse(p)
+
+        self.assertEqual(9, cert_type.ext_type)
+        self.assertEqual([], cert_type.cert_types)
+
+    def test_parse_with_list(self):
+        cert_type = ClntCertTypeExtension()
+
+        p = Parser(bytearray(b'\x02\x01\x00'))
+
+        cert_type = cert_type.parse(p)
+
+        self.assertEqual([1, 0], cert_type.cert_types)
+
+    def test_parse_with_length_long_by_one(self):
+        cert_type = ClntCertTypeExtension()
+
+        p = Parser(bytearray(b'\x03\x01\x00'))
+
+        with self.assertRaises(SyntaxError):
+            cert_type.parse(p)
 
 class TestSRPExtension(unittest.TestCase):
     def test___init___(self):

--- a/unit_tests/test_tlslite_tlsextension.py
+++ b/unit_tests/test_tlslite_tlsextension.py
@@ -60,6 +60,20 @@ class TestTLSExtension(unittest.TestCase):
         with self.assertRaises(SyntaxError) as context:
             TLSExtension().parse(p)
 
+    def test_parse_with_sni_ext(self):
+        p = Parser(bytearray(
+            b'\x00\x00' +   # type of extension - SNI (0)
+            b'\x00\x10' +   # length of extension - 16 bytes
+            b'\x00\x0e' +   # length of array
+            b'\x00' +       # type of entry - host_name (0)
+            b'\x00\x0b' +   # length of name - 11 bytes
+            # UTF-8 encoding of example.com
+            b'\x65\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d'))
+
+        tls_extension = TLSExtension().parse(p)
+
+        self.assertEqual(bytearray(b'example.com'), tls_extension.host_names[0])
+
 class TestSNIExtension(unittest.TestCase):
     def test___init__(self):
         server_name = SNIExtension()

--- a/unit_tests/test_tlslite_utils_codec.py
+++ b/unit_tests/test_tlslite_utils_codec.py
@@ -154,5 +154,15 @@ class TestParser(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             p.getFixBytes(10)
 
+    def test_getRemainingLength(self):
+        p = Parser(bytearray(
+            b'\x00\x01\x05'
+            ))
+
+        self.assertEqual(1, p.get(2))
+        self.assertEqual(1, p.getRemainingLength())
+        self.assertEqual(5, p.get(1))
+        self.assertEqual(0, p.getRemainingLength())
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As the name suggests, the extensions mechanism should be extensible this patch series makes it so.

Implements:
 - generic `TLSExtension` class (e.g. for use when the extension doesn't require a payload)
 - `SNIExtension` for handling server_name extension in full of its potential (support for more than one name and names different than domain names)
 - `NPNExtension` for handling the next protocol extension
 - `SRPExtension` for handling secure remote password
 - `ClntCertTypeExtension` for handling the cert_type extension (ClientHello variant)

Makes parsing and serializing extensions generic, moves it out of `ClientHello` class.

As a side effect, `ClientHello` now preserves the order of extensions, doesn't drop additional names from SNI and can also send and receive arbitrary extensions without any additional changes. Fully preserves old API using property mechanism.

Includes extension-specific test coverage for the introduced classes and some extra documentation for `ClientHello` class.