### PR TITLE
Convert Server Hello extensions to a list

### DIFF
--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -409,6 +409,74 @@ class ClientCertTypeExtension(TLSExtension):
 
         return self
 
+class ServerCertTypeExtension(TLSExtension):
+    """
+    This class handles the Certificate Type extension (variant sent by server)
+    defined in RFC 6091.
+
+    @type ext_type: int
+    @ivar ext_type: byneruc ttoe if Certificate Type extension, i.e. 9
+
+    @type ext_data: bytearray
+    @ivar ext_data: raw representation of the extension data
+
+    @type cert_type: int
+    @ivar cert_type: the certificate type selected by server
+    """
+
+    def __init__(self):
+        """
+        Create an instance of ServerCertTypeExtension
+
+        See also: L{create} and L{parse}
+        """
+        self.cert_type = None
+
+    @property
+    def ext_type(self):
+        """
+        Return the type of TLS extension, in this case - 9
+
+        @rtype: int
+        """
+        return ExtensionType.cert_type
+
+    @property
+    def ext_data(self):
+        """
+        Return the raw encoding of the extension data
+
+        @rtype: bytearray
+        """
+        if self.cert_type is None:
+            return bytearray(0)
+
+        w = Writer()
+        w.add(self.cert_type, 1)
+
+        return w.bytes
+
+    def create(self, val):
+        """Create an instance for sending the extension to client.
+
+        @type val: int
+        @param val: selected type of certificate
+        """
+        self.cert_type = val
+        return self
+
+    def parse(self, p):
+        """Parse the extension from on the wire format
+
+        @type p: L{Parser}
+        @param p: parser with data
+        """
+        self.cert_type = p.get(1)
+        if p.getRemainingLength() > 0:
+            raise SyntaxError()
+
+        return self
+
 class SRPExtension(TLSExtension):
     """
     This class handles the Secure Remote Password protocol TLS extension

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -86,6 +86,19 @@ class TestTLSExtension(unittest.TestCase):
 
         self.assertTrue(a == b)
 
+    def test_parse_of_server_hello_extension(self):
+        ext = TLSExtension(server=True)
+
+        p = Parser(bytearray(
+            b'\x00\x09' +       # extension type - cert_type (9)
+            b'\x00\x01' +       # extension length - 1 byte
+            b'\x01'             # certificate type - OpenGPG (1)
+            ))
+
+        ext = ext.parse(p)
+
+        self.assertEqual(1, ext.cert_type)
+
 class TestSNIExtension(unittest.TestCase):
     def test___init__(self):
         server_name = SNIExtension()


### PR DESCRIPTION
this patch set converts the internal representation of extensions in server hello object to a list so that it is easier to support more extensions and do proper testing of specific extension parsers

Adds:
 * tests for cert_type and next_proto_negotiation extensions in ServerHello
 * server hello variant of cert_type extension (ServerCertTypeExtension)
 * turns the TLSExtension parser generic (able to handle both client hello and server hello extensions)
 * adds a TACK extension parser (the actual verification still requires external library)