### PR TITLE
Introduce some debugging aids

### DIFF
--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -149,6 +149,15 @@ class TLSExtension(object):
         else:
             return False
 
+    def __repr__(self):
+        """ Output human readable representation of object
+
+        @rtype: str
+        """
+        return "TLSExtension(ext_type={0!r}, ext_data={1!r},"\
+                " server_type={2!r})".format(
+                        self.ext_type, self.ext_data, self.server_type)
+
 class SNIExtension(TLSExtension):
     """
     Class for handling Server Name Indication (server_name) extension from
@@ -201,6 +210,14 @@ class SNIExtension(TLSExtension):
         See also: L{create} and L{parse}.
         """
         self.server_names = None
+
+    def __repr__(self):
+        """
+        Return programmer-readable representation of extension
+
+        @rtype: str
+        """
+        return "SNIExtension(server_names={0!r})".format(self.server_names)
 
     def create(self, hostname=None, host_names=None, server_names=None):
         """
@@ -380,6 +397,14 @@ class ClientCertTypeExtension(TLSExtension):
 
         self.cert_types = None
 
+    def __repr__(self):
+        """ Return programmer-centric representation of extension
+
+        @rtype: str
+        """
+        return "ClientCertTypeExtension(cert_types={0!r})"\
+                .format(self.cert_types)
+
     @property
     def ext_type(self):
         """
@@ -461,6 +486,13 @@ class ServerCertTypeExtension(TLSExtension):
         """
         self.cert_type = None
 
+    def __repr__(self):
+        """ Return programmer-centric description of object
+
+        @rtype: str
+        """
+        return "ServerCertTypeExtension(cert_type={0!r})".format(self.cert_type)
+
     @property
     def ext_type(self):
         """
@@ -529,6 +561,14 @@ class SRPExtension(TLSExtension):
         """
 
         self.identity = None
+
+    def __repr__(self):
+        """
+        Return programmer-centric description of extension
+
+        @rtype: str
+        """
+        return "SRPExtension(identity={0!r})".format(self.identity)
 
     @property
     def ext_type(self):
@@ -615,6 +655,14 @@ class NPNExtension(TLSExtension):
 
         self.protocols = None
 
+    def __repr__(self):
+        """
+        Create programmer-readable version of representation
+
+        @rtype: str
+        """
+        return "NPNExtension(protocols={0!r})".format(self.protocols)
+
     @property
     def ext_type(self):
         """ Return the type of TLS extension, in this case - 13172
@@ -692,6 +740,19 @@ class TACKExtension(TLSExtension):
             self.expiration = 0
             self.target_hash = bytearray(32)
             self.signature = bytearray(64)
+
+        def __repr__(self):
+            """
+            Return programmmer readable representation of TACK object
+
+            @rtype: str
+            """
+            return "TACK(public_key={0!r}, min_generation={1!r}, "\
+                    "generation={2!r}, expiration={3!r}, target_hash={4!r}, "\
+                    "signature={5!r})".format(
+                            self.public_key, self.min_generation,
+                            self.generation, self.expiration, self.target_hash,
+                            self.signature)
 
         def create(self, public_key, min_generation, generation, expiration,
                 target_hash, signature):
@@ -784,6 +845,15 @@ class TACKExtension(TLSExtension):
 
         self.tacks = []
         self.activation_flags = 0
+
+    def __repr__(self):
+        """
+        Create a programmer readable representation of TACK extension
+
+        @rtype: str
+        """
+        return "TACKExtension(activation_flags={0!r}, tacks={1!r})".format(
+                self.activation_flags, self.tacks)
 
     @property
     def ext_type(self):

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -107,6 +107,27 @@ class Alert(object):
         w.add(self.description, 1)
         return w.bytes
 
+    @property
+    def level_name(self):
+        matching = [x[0] for x in AlertLevel.__dict__.items()
+                if x[1] == self.level]
+        if len(matching) == 0:
+            return "unknown({0})".format(self.level)
+        else:
+            return str(matching[0])
+
+    @property
+    def description_name(self):
+        matching = [x[0] for x in AlertDescription.__dict__.items()
+                if x[1] == self.description]
+        if len(matching) == 0:
+            return "unknown({0})".format(self.description)
+        else:
+            return str(matching[0])
+
+    def __str__(self):
+        return "Alert, level:{0}, description:{1}".format(self.level_name,
+                self.description_name)
 
 class HandshakeMsg(object):
     def __init__(self, handshakeType):

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -202,6 +202,18 @@ class ClientHello(HandshakeMsg):
 
         return ret
 
+    def __repr__(self):
+        """
+        Return machine readable representation of Client Hello
+
+        @rtype: str
+        """
+        return "ClientHello(ssl2={0}, client_version=({1[0]}.{1[1]}), "\
+                "random={2!r}, session_id={3!r}, cipher_suites={4!r}, "\
+                "compression_methods={5}, extensions={6})".format(\
+                self.ssl2, self.client_version, self.random, self.session_id,
+                self.cipher_suites, self.compression_methods, self.extensions)
+
     def getExtension(self, ext_type):
         """
         Returns extension of given type if present, None otherwise

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -522,6 +522,21 @@ class ServerHello(HandshakeMsg):
         self._tack_ext = None
         self.extensions = None
 
+    def __str__(self):
+        base = "server_hello,length({0}),version({1[0]}.{1[1]}),random(...),"\
+                "session ID({2!r}),cipher({3:#x}),compression method({4})"\
+                .format(len(self.write())-4, self.server_version,
+                        self.session_id, self.cipher_suite,
+                        self.compression_method)
+
+        if self.extensions is None:
+            return base
+
+        ret = ",extensions["
+        ret += ",".join(repr(x) for x in self.extensions)
+        ret += "]"
+        return base + ret
+
     def getExtension(self, ext_type):
         """Return extension of a given type, None if extension of given type
         is not present

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -48,6 +48,20 @@ class RecordHeader3(object):
         self.ssl2 = False
         return self
 
+    @property
+    def type_name(self):
+        matching = [x[0] for x in ContentType.__dict__.items()
+                if x[1] == self.type]
+        if len(matching) == 0:
+            return "unknown(" + str(self.type) + ")"
+        else:
+            return str(matching[0])
+
+    def __str__(self):
+        return "SSLv3 record,version({0[0]}.{0[1]}),"\
+                "content type({1}),length({2})".format(self.version,
+                        self.type_name, self.length)
+
 class RecordHeader2(object):
     def __init__(self):
         self.type = 0

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -179,6 +179,29 @@ class ClientHello(HandshakeMsg):
         self.compression_methods = []   # a list of 8-bit values
         self.extensions = None
 
+    def __str__(self):
+        """
+        Return human readable representation of Client Hello
+
+        @rtype: str
+        """
+
+        if self.session_id.count(bytearray(b'\x00')) == len(self.session_id)\
+            and len(self.session_id) != 0:
+            session = "bytearray(b'\\x00'*{0})".format(len(self.session_id))
+        else:
+            session = repr(self.session_id)
+        ret = "client_hello,version({0[0]}.{0[1]}),random(...),"\
+                "session ID({1!s}),cipher suites({2!r}),"\
+                "compression methods({3!r})".format(
+                        self.client_version, session,
+                        self.cipher_suites, self.compression_methods)
+
+        if self.extensions is not None:
+            ret += ",extensions({0!r})".format(self.extensions)
+
+        return ret
+
     def getExtension(self, ext_type):
         """
         Returns extension of given type if present, None otherwise

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -62,6 +62,10 @@ class RecordHeader3(object):
                 "content type({1}),length({2})".format(self.version,
                         self.type_name, self.length)
 
+    def __repr__(self):
+        return "RecordHeader3(type={0}, version=({1[0]}.{1[1]}), length={2})".\
+                format(self.type, self.version, self.length)
+
 class RecordHeader2(object):
     def __init__(self):
         self.type = 0

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -129,6 +129,10 @@ class Alert(object):
         return "Alert, level:{0}, description:{1}".format(self.level_name,
                 self.description_name)
 
+    def __repr__(self):
+        return "Alert(level={0}, description={1})".format(self.level,
+                self.description)
+
 class HandshakeMsg(object):
     def __init__(self, handshakeType):
         self.contentType = ContentType.handshake

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -537,6 +537,14 @@ class ServerHello(HandshakeMsg):
         ret += "]"
         return base + ret
 
+    def __repr__(self):
+        return "ServerHello(server_version=({0[0]}.{0[1]}), random={1!r}, "\
+                "session_id={2!r}, cipher_suite={3}, compression_method={4}, "\
+                "_tack_ext={5}, extensions={6!r})".format(\
+                self.server_version, self.random, self.session_id,
+                self.cipher_suite, self.compression_method, self._tack_ext,
+                self.extensions)
+
     def getExtension(self, ext_type):
         """Return extension of a given type, None if extension of given type
         is not present

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -100,6 +100,14 @@ class TestTLSExtension(unittest.TestCase):
 
         self.assertEqual(1, ext.cert_type)
 
+    def test___repr__(self):
+        ext = TLSExtension()
+        ext = ext.create(0, bytearray(b'\x00\x00'))
+
+        self.assertEqual("TLSExtension(ext_type=0, "\
+                "ext_data=bytearray(b'\\x00\\x00'), server_type=False)",
+                repr(ext))
+
 class TestSNIExtension(unittest.TestCase):
     def test___init__(self):
         server_name = SNIExtension()
@@ -424,6 +432,18 @@ class TestSNIExtension(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             server_name = server_name.parse(p)
 
+    def test___repr__(self):
+        server_name = SNIExtension()
+        server_name = server_name.create(
+                server_names=[
+                    SNIExtension.ServerName(0, bytearray(b'example.com')),
+                    SNIExtension.ServerName(1, bytearray(b'\x04\x01'))])
+
+        self.assertEqual("SNIExtension(server_names=["\
+                "ServerName(name_type=0, name=bytearray(b'example.com')), "\
+                "ServerName(name_type=1, name=bytearray(b'\\x04\\x01'))])",
+                repr(server_name))
+
 class TestClientCertTypeExtension(unittest.TestCase):
     def test___init___(self):
         cert_type = ClientCertTypeExtension()
@@ -491,6 +511,13 @@ class TestClientCertTypeExtension(unittest.TestCase):
         with self.assertRaises(SyntaxError):
             cert_type.parse(p)
 
+    def test___repr__(self):
+        cert_type = ClientCertTypeExtension()
+        cert_type = cert_type.create([0, 1])
+
+        self.assertEqual("ClientCertTypeExtension(cert_types=[0, 1])",
+                repr(cert_type))
+
 class TestServerCertTypeExtension(unittest.TestCase):
     def test___init__(self):
         cert_type = ServerCertTypeExtension()
@@ -539,6 +566,12 @@ class TestServerCertTypeExtension(unittest.TestCase):
             b'\x00\x01' +       # extension length - 1 byte
             b'\x01'             # selected certificate type - OpenPGP (1)
             ), cert_type.write())
+
+    def test___repr__(self):
+        cert_type = ServerCertTypeExtension().create(1)
+
+        self.assertEqual("ServerCertTypeExtension(cert_type=1)",
+                repr(cert_type))
 
 class TestSRPExtension(unittest.TestCase):
     def test___init___(self):
@@ -608,6 +641,13 @@ class TestSRPExtension(unittest.TestCase):
 
         with self.assertRaises(SyntaxError):
             srp_extension = srp_extension.parse(p)
+
+    def test___repr__(self):
+        srp_extension = SRPExtension()
+        srp_extension = srp_extension.create(bytearray(b'user'))
+
+        self.assertEqual("SRPExtension(identity=bytearray(b'user'))",
+                repr(srp_extension))
 
 class TestNPNExtension(unittest.TestCase):
     def test___init___(self):
@@ -708,6 +748,12 @@ class TestNPNExtension(unittest.TestCase):
 
         with self.assertRaises(SyntaxError):
             npn_extension.parse(p)
+
+    def test___repr__(self):
+        npn_extension = NPNExtension().create([bytearray(b'http/1.1')])
+
+        self.assertEqual("NPNExtension(protocols=[bytearray(b'http/1.1')])",
+                repr(npn_extension))
 
 class TestTACKExtension(unittest.TestCase):
     def test___init__(self):
@@ -826,6 +872,23 @@ class TestTACKExtension(unittest.TestCase):
                 bytearray(b'\x06'*64))
         self.assertEqual([tack], tack_ext.tacks)
         self.assertEqual(1, tack_ext.activation_flags)
+
+    def test___repr__(self):
+        tack = TACKExtension.TACK().create(
+                bytearray(b'\x00'),
+                1,
+                2,
+                3,
+                bytearray(b'\x04'),
+                bytearray(b'\x05'))
+        tack_ext = TACKExtension().create([tack], 1)
+        self.maxDiff = None
+        self.assertEqual("TACKExtension(activation_flags=1, tacks=["\
+                "TACK(public_key=bytearray(b'\\x00'), min_generation=1, "\
+                "generation=2, expiration=3, target_hash=bytearray(b'\\x04'), "\
+                "signature=bytearray(b'\\x05'))"\
+                "])",
+                repr(tack_ext))
 
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -2,9 +2,10 @@
 # see LICENCE file for legal information regarding use of this file
 
 import unittest
-from tlslite.messages import ClientHello, ServerHello, RecordHeader3
+from tlslite.messages import ClientHello, ServerHello, RecordHeader3, Alert
 from tlslite.utils.codec import Parser
-from tlslite.constants import CipherSuite, CertificateType, ContentType
+from tlslite.constants import CipherSuite, CertificateType, ContentType, \
+        AlertLevel, AlertDescription
 from tlslite.extensions import SNIExtension, ClientCertTypeExtension, \
     SRPExtension, TLSExtension
 
@@ -707,6 +708,36 @@ class TestRecordHeader3(unittest.TestCase):
 
         self.assertEqual("RecordHeader3(type=23, version=(3.0), length=256)",
                 repr(rh))
+
+class TestAlert(unittest.TestCase):
+    def test_level_name(self):
+        alert = Alert().create(AlertDescription.record_overflow,
+                AlertLevel.fatal)
+
+        self.assertEqual("fatal", alert.level_name)
+
+    def test_level_name_with_wrong_level(self):
+        alert = Alert().create(AlertDescription.close_notify, 11)
+
+        self.assertEqual("unknown(11)", alert.level_name)
+
+    def test_description_name(self):
+        alert = Alert().create(AlertDescription.record_overflow,
+                AlertLevel.fatal)
+
+        self.assertEqual("record_overflow", alert.description_name)
+
+    def test_description_name_with_wrong_id(self):
+        alert = Alert().create(1)
+
+        self.assertEqual("unknown(1)", alert.description_name)
+
+    def test___str__(self):
+        alert = Alert().create(AlertDescription.record_overflow,
+                AlertLevel.fatal)
+
+        self.assertEqual("Alert, level:fatal, description:record_overflow",
+                str(alert))
 
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -642,6 +642,22 @@ class TestServerHello(unittest.TestCase):
             b'\x68\x74\x74\x70\x2f\x31\x2e\x31'
             )), list(server_hello.write()))
 
+    def test___str__(self):
+        server_hello = ServerHello()
+        server_hello = server_hello.create(
+                (3,0),
+                bytearray(b'\x00'*32),
+                bytearray(b'\x01\x20'),
+                34500,
+                0,
+                None,
+                None)
+
+        self.assertEqual("server_hello,length(40),version(3.0),random(...),"\
+                "session ID(bytearray(b'\\x01 ')),cipher(0x86c4),"\
+                "compression method(0)",
+                str(server_hello))
+
 class TestRecordHeader3(unittest.TestCase):
     def test_type_name(self):
         rh = RecordHeader3()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -377,6 +377,33 @@ class TestClientHello(unittest.TestCase):
                 b'\x65\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d'
                 )), list(client_hello.write()))
 
+    def test___str__(self):
+        client_hello = ClientHello().create((3,0), bytearray(4), bytearray(0),\
+                [])
+
+        self.assertEqual("client_hello,version(3.0),random(...),"\
+                "session ID(bytearray(b'')),cipher suites([]),"\
+                "compression methods([0])", str(client_hello))
+
+    def test___str___with_all_null_session_id(self):
+        client_hello = ClientHello().create((3,0), bytearray(4), bytearray(10),\
+                [])
+
+        self.assertEqual("client_hello,version(3.0),random(...),"\
+                "session ID(bytearray(b'\\x00'*10)),cipher suites([]),"\
+                "compression methods([0])", str(client_hello))
+
+    def test___str___with_extensions(self):
+        client_hello = ClientHello().create((3,0), bytearray(4), bytearray(0),\
+                [],  extensions=[TLSExtension().create(0, bytearray(b'\x00'))])
+
+        self.assertEqual("client_hello,version(3.0),random(...),"\
+                "session ID(bytearray(b'')),cipher suites([]),"\
+                "compression methods([0]),extensions(["\
+                "TLSExtension(ext_type=0, ext_data=bytearray(b'\\x00'), "\
+                "server_type=False)])",
+                str(client_hello))
+
 class TestServerHello(unittest.TestCase):
     def test___init__(self):
         server_hello = ServerHello()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -664,5 +664,12 @@ class TestRecordHeader3(unittest.TestCase):
                 "content type(unknown(12)),length(0)",
                 str(rh))
 
+    def test___repr__(self):
+        rh = RecordHeader3()
+        rh = rh.create((3,0), ContentType.application_data, 256)
+
+        self.assertEqual("RecordHeader3(type=23, version=(3.0), length=256)",
+                repr(rh))
+
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -658,6 +658,27 @@ class TestServerHello(unittest.TestCase):
                 "compression method(0)",
                 str(server_hello))
 
+    def test___repr__(self):
+        server_hello = ServerHello()
+        server_hello = server_hello.create(
+                (3,0),
+                bytearray(b'\x00'*32),
+                bytearray(0),
+                34500,
+                0,
+                None,
+                None,
+                extensions=[])
+        self.maxDiff = None
+        self.assertEqual("ServerHello(server_version=(3.0), "\
+                "random=bytearray(b'\\x00\\x00"\
+                "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00"\
+                "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00"\
+                "\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x00'), "\
+                "session_id=bytearray(b''), "\
+                "cipher_suite=34500, compression_method=0, _tack_ext=None, "\
+                "extensions=[])", repr(server_hello))
+
 class TestRecordHeader3(unittest.TestCase):
     def test_type_name(self):
         rh = RecordHeader3()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -739,5 +739,11 @@ class TestAlert(unittest.TestCase):
         self.assertEqual("Alert, level:fatal, description:record_overflow",
                 str(alert))
 
+    def test___repr__(self):
+        alert = Alert().create(AlertDescription.record_overflow,
+                AlertLevel.fatal)
+
+        self.assertEqual("Alert(level=2, description=22)", repr(alert))
+
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -2,9 +2,9 @@
 # see LICENCE file for legal information regarding use of this file
 
 import unittest
-from tlslite.messages import ClientHello, ServerHello
+from tlslite.messages import ClientHello, ServerHello, RecordHeader3
 from tlslite.utils.codec import Parser
-from tlslite.constants import CipherSuite, CertificateType
+from tlslite.constants import CipherSuite, CertificateType, ContentType
 from tlslite.extensions import SNIExtension, ClientCertTypeExtension, \
     SRPExtension, TLSExtension
 
@@ -641,6 +641,28 @@ class TestServerHello(unittest.TestCase):
             # utf-8 endoding of 'http/1.1'
             b'\x68\x74\x74\x70\x2f\x31\x2e\x31'
             )), list(server_hello.write()))
+
+class TestRecordHeader3(unittest.TestCase):
+    def test_type_name(self):
+        rh = RecordHeader3()
+        rh = rh.create((3,0), ContentType.application_data, 0)
+
+        self.assertEqual("application_data", rh.type_name)
+
+    def test___str__(self):
+        rh = RecordHeader3()
+        rh = rh.create((3,0), ContentType.handshake, 12)
+
+        self.assertEqual("SSLv3 record,version(3.0),content type(handshake)," +\
+                "length(12)", str(rh))
+
+    def test___str___with_invalid_content_type(self):
+        rh = RecordHeader3()
+        rh = rh.create((3,3), 12, 0)
+
+        self.assertEqual("SSLv3 record,version(3.3)," +\
+                "content type(unknown(12)),length(0)",
+                str(rh))
 
 if __name__ == '__main__':
     unittest.main()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -404,6 +404,17 @@ class TestClientHello(unittest.TestCase):
                 "server_type=False)])",
                 str(client_hello))
 
+    def test___repr__(self):
+        client_hello = ClientHello().create((3,3), bytearray(1), bytearray(0),\
+                [], extensions=[TLSExtension().create(0, bytearray(0))])
+
+        self.assertEqual("ClientHello(ssl2=False, client_version=(3.3), "\
+                "random=bytearray(b'\\x00'), session_id=bytearray(b''), "\
+                "cipher_suites=[], compression_methods=[0], "\
+                "extensions=[TLSExtension(ext_type=0, "\
+                "ext_data=bytearray(b''), server_type=False)])",
+                repr(client_hello))
+
 class TestServerHello(unittest.TestCase):
     def test___init__(self):
         server_hello = ServerHello()


### PR DESCRIPTION
Make it possible to easily query the state of some common message types.

Adds repr() handlers for ClientHello, Alert, all extensions, ServerHello and RecordLayer3 types. Also str() handlers for all the above with exception of extensions.