### PR TITLE
100% branch test coverage for tlslite.extensions

### DIFF
--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -72,8 +72,8 @@ class TLSExtension(object):
         client hello or server hello messages
 
         @type  ext_type: int
-        @param ext_type: type of the extension encoded as an integer between M{0}
-            and M{2^16-1}
+        @param ext_type: type of the extension encoded as an integer between
+            M{0} and M{2^16-1}
         @type  data: bytearray
         @param data: raw data representing extension on the wire
         @rtype: L{TLSExtension}
@@ -250,16 +250,16 @@ class SNIExtension(TLSExtension):
             self.server_names = []
 
         if hostname:
-            self.server_names+=[SNIExtension.ServerName(NameType.host_name,\
+            self.server_names += [SNIExtension.ServerName(NameType.host_name,\
                     hostname)]
 
         if host_names:
-            self.server_names+=\
+            self.server_names +=\
                     [SNIExtension.ServerName(NameType.host_name, x) for x in\
                     host_names]
 
         if server_names:
-            self.server_names+=server_names
+            self.server_names += server_names
 
         return self
 
@@ -484,6 +484,7 @@ class ServerCertTypeExtension(TLSExtension):
 
         See also: L{create} and L{parse}
         """
+
         self.cert_type = None
 
     def __repr__(self):
@@ -908,11 +909,12 @@ class TACKExtension(TLSExtension):
 
         return self
 
-TLSExtension._universal_extensions = { ExtensionType.server_name : SNIExtension,
+TLSExtension._universal_extensions = {
+        ExtensionType.server_name : SNIExtension,
         ExtensionType.cert_type : ClientCertTypeExtension,
         ExtensionType.srp : SRPExtension,
-        ExtensionType.supports_npn : NPNExtension }
+        ExtensionType.supports_npn : NPNExtension}
 
 TLSExtension._server_extensions = {
         ExtensionType.cert_type : ServerCertTypeExtension,
-        ExtensionType.tack : TACKExtension }
+        ExtensionType.tack : TACKExtension}

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -133,8 +133,7 @@ class TLSExtension(object):
         # don't require specific handlers and indicate option by mere presence
         self.ext_type = ext_type
         self.ext_data = p.getFixBytes(ext_length)
-        if len(self.ext_data) != ext_length:
-            raise SyntaxError()
+        assert len(self.ext_data) == ext_length
         return self
 
     def __eq__(self, that):

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -10,6 +10,7 @@ from __future__ import generators
 from .utils.codec import Writer, Parser
 from collections import namedtuple
 from .constants import NameType, ExtensionType
+from .errors import TLSInternalError
 
 class TLSExtension(object):
     """

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -819,19 +819,15 @@ class TACKExtension(TLSExtension):
                     hasattr(other, 'expiration') and\
                     hasattr(other, 'target_hash') and\
                     hasattr(other, 'signature'):
-                if self.public_key != other.public_key:
+                if self.public_key == other.public_key and\
+                   self.min_generation == other.min_generation and\
+                   self.generation == other.generation and\
+                   self.expiration == other.expiration and\
+                   self.target_hash == other.target_hash and\
+                   self.signature == other.signature:
+                    return True
+                else:
                     return False
-                if self.min_generation != other.min_generation:
-                    return False
-                if self.generation != other.generation:
-                    return False
-                if self.expiration != other.expiration:
-                    return False
-                if self.target_hash != other.target_hash:
-                    return False
-                if self.signature != other.signature:
-                    return False
-                return True
             else:
                 return False
 

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -834,9 +834,7 @@ class TestTACKExtension(unittest.TestCase):
                 bytearray(b'\x05'*32),
                 bytearray(b'\x06'*64))
 
-        # XXX missing import in tlslite.extensions
-        with self.assertRaises(NameError):
-        #with self.assertRaises(TLSInternalError):
+        with self.assertRaises(TLSInternalError):
             tack.write()
 
     def test_tack_write_with_bad_length_target_hash(self):
@@ -848,9 +846,7 @@ class TestTACKExtension(unittest.TestCase):
                 bytearray(b'\x05'*33),
                 bytearray(b'\x06'*64))
 
-        # XXX missing import in tlslite.extensions
-        with self.assertRaises(NameError):
-        #with self.assertRaises(TLSInternalError):
+        with self.assertRaises(TLSInternalError):
             tack.write()
 
     def test_tack_write_with_bad_length_signature(self):
@@ -862,9 +858,7 @@ class TestTACKExtension(unittest.TestCase):
                 bytearray(b'\x05'*32),
                 bytearray(b'\x06'*65))
 
-        # XXX missing import in tlslite.extensions
-        with self.assertRaises(NameError):
-        #with self.assertRaises(TLSInternalError):
+        with self.assertRaises(TLSInternalError):
             tack.write()
 
     def test_tack_parse(self):

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -87,6 +87,16 @@ class TestTLSExtension(unittest.TestCase):
 
         self.assertTrue(a == b)
 
+    def test_equality_with_nearly_good_object(self):
+        class TestClass(object):
+            def __init__(self):
+                self.ext_type = 0
+
+        a = TLSExtension().create(0, bytearray(b'\x00\x00'))
+        b = TestClass()
+
+        self.assertFalse(a == b)
+
     def test_parse_of_server_hello_extension(self):
         ext = TLSExtension(server=True)
 


### PR DESCRIPTION
 * Increase the branch-based test coverage for tlslite.extensions to 100%
 * fix a missing import for TLSInternalError
 * fix few minor issues reported by pylint