### PR TITLE
Move server hello sanity checks to external class

### DIFF
--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -46,6 +46,7 @@ class ExtensionType:    # RFC 6066 / 4366
     cert_type = 9       # RFC 6091
     tack = 0xF300
     supports_npn = 13172
+    renegotiation_info = 0xFF01 # RFC5746
     
 class NameType:
     host_name = 0

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -189,3 +189,8 @@ class TLSInternalError(TLSError):
 class TLSProtocolException(BaseTLSException):
     """Exceptions used internally for handling errors in received messages"""
     pass
+
+class TLSIllegalParameterException(TLSProtocolException):
+    """Parameters specified in message were incorrect or invalid
+    """
+    pass

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -14,7 +14,15 @@ import socket
 
 from .constants import AlertDescription, AlertLevel
 
-class TLSError(Exception):
+class BaseTLSException(Exception):
+    """Metaclass for TLS Lite exceptions.
+
+    Look to L{TLSError} for exceptions that should be caught by tlslite
+    consumers
+    """
+    pass
+
+class TLSError(BaseTLSException):
     """Base class for all TLS Lite exceptions."""
     
     def __str__(self):
@@ -172,5 +180,12 @@ class TLSUnsupportedError(TLSError):
     pass
 
 class TLSInternalError(TLSError):
-    """The internal state of object is unexpected or invalid"""
+    """The internal state of object is unexpected or invalid.
+
+    Caused by incorrect use of API.
+    """
+    pass
+
+class TLSProtocolException(BaseTLSException):
+    """Exceptions used internally for handling errors in received messages"""
     pass

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -194,3 +194,8 @@ class TLSIllegalParameterException(TLSProtocolException):
     """Parameters specified in message were incorrect or invalid
     """
     pass
+
+class TLSProtocolVersionException(TLSProtocolException):
+    """Protocol version selected by peer is incorrect or invalid
+    """
+    pass

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -532,13 +532,6 @@ class ClientHello(HandshakeMsg):
             w.bytes += w2.bytes
         return self.postWrite(w)
 
-class BadNextProtos(Exception):
-    def __init__(self, l):
-        self.length = l
-
-    def __str__(self):
-        return 'Cannot encode a list of next protocols because it contains an element with invalid length %d. Element lengths must be 0 < x < 256' % self.length
-
 class ServerHello(HandshakeMsg):
     """server_hello message
 

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -628,6 +628,17 @@ class ServerHello(HandshakeMsg):
         else:
             return None
 
+    def getExtensionsIDs(self):
+        """
+        Return a list of extension IDs present in message
+
+        @rtype: list of int
+        """
+        if self.extensions is None:
+            return []
+        else:
+            return [x.ext_type for x in self.extensions]
+
     def addExtension(self, ext):
         """
         Add extension to internal list of extensions

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -234,6 +234,17 @@ class ClientHello(HandshakeMsg):
         else:
             return None
 
+    def getExtensionsIDs(self):
+        """
+        Returns a list of all ID types present in message
+
+        @rtype: list of int
+        """
+        if self.extensions is None:
+            return []
+        else:
+            return [x.ext_type for x in self.extensions]
+
     def addExtension(self, ext):
         """
         Adds extension to internal list of extensions

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -580,21 +580,11 @@ class TLSConnection(TLSRecordLayer):
                 "Server responded with incorrect certificate type"):
                 yield result
         if serverHello.tackExt:            
-            if not clientHello.tack:
-                for result in self._sendError(\
-                    AlertDescription.illegal_parameter,
-                    "Server responded with unrequested Tack Extension"):
-                    yield result
             if not serverHello.tackExt.verifySignatures():
                 for result in self._sendError(\
                     AlertDescription.decrypt_error,
                     "TackExtension contains an invalid signature"):
                     yield result
-        if serverHello.next_protos and not clientHello.supports_npn:
-            for result in self._sendError(\
-                AlertDescription.illegal_parameter,
-                "Server responded with unrequested NPN Extension"):
-                yield result
         yield serverHello
 
     def _clientSelectNextProto(self, nextProtos, serverHello):

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -590,16 +590,16 @@ class TLSConnection(TLSRecordLayer):
                     AlertDescription.illegal_parameter,
                     "Server responded with unrequested Tack Extension"):
                     yield result
-        if serverHello.next_protos and not clientHello.supports_npn:
-            for result in self._sendError(\
-                AlertDescription.illegal_parameter,
-                "Server responded with unrequested NPN Extension"):
-                yield result
             if not serverHello.tackExt.verifySignatures():
                 for result in self._sendError(\
                     AlertDescription.decrypt_error,
                     "TackExtension contains an invalid signature"):
                     yield result
+        if serverHello.next_protos and not clientHello.supports_npn:
+            for result in self._sendError(\
+                AlertDescription.illegal_parameter,
+                "Server responded with unrequested NPN Extension"):
+                yield result
         yield serverHello
 
     def _clientSelectNextProto(self, nextProtos, serverHello):

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -562,23 +562,13 @@ class TLSConnection(TLSRecordLayer):
                     AlertDescription.illegal_parameter,
                     str(e)):
                 yield result
+        except TLSProtocolVersionException as e:
+            for result in self._sendError(\
+                    AlertDescription.protocol_version,
+                    str(e)):
+                yield result
 
         #Check ServerHello
-        if serverHello.server_version < settings.minVersion:
-            for result in self._sendError(\
-                AlertDescription.protocol_version,
-                "Too old version: %s" % str(serverHello.server_version)):
-                yield result
-        if serverHello.server_version > settings.maxVersion:
-            for result in self._sendError(\
-                AlertDescription.protocol_version,
-                "Too new version: %s" % str(serverHello.server_version)):
-                yield result
-        if serverHello.certificate_type not in clientHello.certificate_types:
-            for result in self._sendError(\
-                AlertDescription.illegal_parameter,
-                "Server responded with incorrect certificate type"):
-                yield result
         if serverHello.tackExt:            
             if not serverHello.tackExt.verifySignatures():
                 for result in self._sendError(\

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -579,11 +579,6 @@ class TLSConnection(TLSRecordLayer):
                 AlertDescription.illegal_parameter,
                 "Server responded with incorrect certificate type"):
                 yield result
-        if serverHello.compression_method != 0:
-            for result in self._sendError(\
-                AlertDescription.illegal_parameter,
-                "Server responded with incorrect compression method"):
-                yield result
         if serverHello.tackExt:            
             if not clientHello.tack:
                 for result in self._sendError(\

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -574,11 +574,6 @@ class TLSConnection(TLSRecordLayer):
                 AlertDescription.protocol_version,
                 "Too new version: %s" % str(serverHello.server_version)):
                 yield result
-        if serverHello.cipher_suite not in clientHello.cipher_suites:
-            for result in self._sendError(\
-                AlertDescription.illegal_parameter,
-                "Server responded with incorrect ciphersuite"):
-                yield result
         if serverHello.certificate_type not in clientHello.certificate_types:
             for result in self._sendError(\
                 AlertDescription.illegal_parameter,

--- a/tlslite/verifiers.py
+++ b/tlslite/verifiers.py
@@ -68,4 +68,9 @@ class ServerHelloVerifier(object):
             raise TLSIllegalParameterException(\
                 "Server responded with incorrect ciphersuite")
 
+        # check for no compression
+        if serverHello.compression_method != 0:
+            raise TLSIllegalParameterException(\
+                "Server responded with incorrect compression method")
+
         return True

--- a/tlslite/verifiers.py
+++ b/tlslite/verifiers.py
@@ -1,0 +1,66 @@
+# Authors:
+#   Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+from .constants import CipherSuite, ExtensionType
+from .handshakesettings import HandshakeSettings
+from .errors import TLSIllegalParameterException
+
+class ServerHelloVerifier(object):
+    """
+    Class for checking the sanity of received ServerHello message given
+    specific settings and clientHello
+    """
+    def __init__(self, clientHello, settings=None):
+        """
+        Set the client hello that was used to request the server hello that
+        will be tested
+
+        @type clientHello: ClientHello
+        @param clientHello: client hello that was sent to server and will be
+            base of verification
+        @type settings: HandshakeSettings
+        @param settings: the security settings to be used for verifying the
+            server, will use defaults if not specified
+        """
+        if settings is None:
+            settings = HandshakeSettings()
+        self.settings = settings
+        self.clientHello = clientHello
+
+    def verify(self, serverHello):
+        """
+        Check if server hello matches the client hello and is ok for given
+        security parameters.
+
+        @type serverHello: ServerHello
+        @param serverHello: server hello to test
+        @rtype: boolean
+        @return: True, exception in case the server hello doesn't pass
+            verification
+        """
+        clientHelloExtensions = self.clientHello.getExtensionsIDs()
+        serverHelloExtensions = serverHello.getExtensionsIDs()
+
+        # tlslite doesn't sent the renegotiation info as an extension
+        # but as a signaling cipher suite value, so expect a renegotiation
+        # info extension even if we didn't send it as an extension
+        if CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV in \
+                self.clientHello.cipher_suites:
+            clientHelloExtensions.append(ExtensionType.renegotiation_info)
+
+        # check if server hello contains only extensions we advertised
+        for serverExtID in serverHelloExtensions:
+            if serverExtID not in clientHelloExtensions:
+                raise TLSIllegalParameterException(\
+                        "Extension ID {0} not present in client hello but "
+                        "provided by server".format(\
+                        serverExtID))
+
+        # check if the server doesn't have duplicate extensions
+        if len(serverHelloExtensions) != len(set(serverHelloExtensions)):
+            raise TLSIllegalParameterException(\
+                    "Duplicate extensions present in server hello")
+
+        return True

--- a/tlslite/verifiers.py
+++ b/tlslite/verifiers.py
@@ -63,4 +63,9 @@ class ServerHelloVerifier(object):
             raise TLSIllegalParameterException(\
                     "Duplicate extensions present in server hello")
 
+        # check if server selected cipher suite we advertised
+        if serverHello.cipher_suite not in self.clientHello.cipher_suites:
+            raise TLSIllegalParameterException(\
+                "Server responded with incorrect ciphersuite")
+
         return True

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -10,7 +10,7 @@ except ImportError:
 from tlslite.messages import ClientHello, ServerHello, RecordHeader3, Alert
 from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType, ContentType, \
-        AlertLevel, AlertDescription
+        AlertLevel, AlertDescription, ExtensionType
 from tlslite.extensions import SNIExtension, ClientCertTypeExtension, \
     SRPExtension, TLSExtension
 
@@ -419,6 +419,20 @@ class TestClientHello(unittest.TestCase):
                 "extensions=[TLSExtension(ext_type=0, "\
                 "ext_data=bytearray(b''), server_type=False)])",
                 repr(client_hello))
+
+    def test_getExtensionsIDs_with_empty_list(self):
+        client_hello = ClientHello()
+
+        self.assertEqual([], client_hello.getExtensionsIDs())
+
+    def test_getExtensionsIDs(self):
+        client_hello = ClientHello()
+        client_hello.extensions = [TLSExtension().create(0, bytearray(0)),
+                SRPExtension()]
+
+        self.assertEqual([ExtensionType.server_name,
+            ExtensionType.srp],
+            client_hello.getExtensionsIDs())
 
 class TestServerHello(unittest.TestCase):
     def test___init__(self):

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -12,7 +12,7 @@ from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType, ContentType, \
         AlertLevel, AlertDescription, ExtensionType
 from tlslite.extensions import SNIExtension, ClientCertTypeExtension, \
-    SRPExtension, TLSExtension
+    SRPExtension, TLSExtension, ServerCertTypeExtension
 
 class TestClientHello(unittest.TestCase):
     def test___init__(self):
@@ -736,6 +736,20 @@ class TestServerHello(unittest.TestCase):
                 "session_id=bytearray(b''), "\
                 "cipher_suite=34500, compression_method=0, _tack_ext=None, "\
                 "extensions=[])", repr(server_hello))
+
+    def test_getExtensionsIDs_with_empty_list(self):
+        server_hello = ServerHello()
+
+        self.assertEqual([], server_hello.getExtensionsIDs())
+
+    def test_getExtensionsIDs(self):
+        server_hello = ServerHello()
+        server_hello.extensions = [TLSExtension().create(0, bytearray(0)),
+                ServerCertTypeExtension()]
+
+        self.assertEqual([ExtensionType.server_name,
+            ExtensionType.cert_type],
+            server_hello.getExtensionsIDs())
 
 class TestRecordHeader3(unittest.TestCase):
     def test_type_name(self):

--- a/unit_tests/test_tlslite_verifiers.py
+++ b/unit_tests/test_tlslite_verifiers.py
@@ -12,8 +12,11 @@ except ImportError:
 from tlslite.verifiers import ServerHelloVerifier
 from tlslite.messages import ClientHello, ServerHello
 from tlslite.constants import CipherSuite, ExtensionType
-from tlslite.extensions import TLSExtension
-from tlslite.errors import TLSIllegalParameterException
+from tlslite.extensions import TLSExtension, ServerCertTypeExtension,\
+        ClientCertTypeExtension
+from tlslite.errors import TLSIllegalParameterException,\
+        TLSProtocolVersionException
+from tlslite.handshakesettings import HandshakeSettings
 
 class TestServerHelloVerifier(unittest.TestCase):
     def test___init__(self):
@@ -109,3 +112,85 @@ class TestServerHelloVerifier(unittest.TestCase):
             verifier.verify(server_hello)
 
         self.assertTrue('incorrect compression' in str(context.exception))
+
+    def test_verify_with_too_low_server_version(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [0]
+        client_hello.client_version = (3, 3)
+
+        settings = HandshakeSettings()
+        settings.minVersion = (3, 2)
+
+        server_hello = ServerHello()
+        server_hello.server_version = (3, 1)
+
+        verifier = ServerHelloVerifier(client_hello, settings)
+
+        with self.assertRaises(TLSProtocolVersionException) as context:
+            verifier.verify(server_hello)
+
+        self.assertTrue('Too old' in str(context.exception))
+
+    def test_verify_with_too_high_server_version(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [0]
+        client_hello.client_version = (3, 3)
+
+        settings = HandshakeSettings()
+        settings.maxVersion = (3, 2)
+
+        server_hello = ServerHello()
+        server_hello.server_version = (3, 3)
+
+        verifier = ServerHelloVerifier(client_hello, settings)
+
+        with self.assertRaises(TLSProtocolVersionException) as context:
+            verifier.verify(server_hello)
+
+        self.assertTrue('Too new' in str(context.exception))
+
+    def test_verify_with_too_high_server_version_selected_by_server(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [0]
+        client_hello.client_version = (3, 2)
+
+        server_hello = ServerHello()
+        server_hello.server_version = (3, 3)
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        with self.assertRaises(TLSProtocolVersionException) as context:
+            verifier.verify(server_hello)
+
+        self.assertTrue('Newer version than adv' in str(context.exception))
+
+    def test_verify_with_correct_cert_type(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [1]
+        client_hello.client_version = (3, 3)
+        client_hello.extensions = [ClientCertTypeExtension().create([0, 1])]
+        server_hello = ServerHello()
+        server_hello.cipher_suite = 1
+        server_hello.server_version = (3, 3)
+        server_hello.extensions = [ServerCertTypeExtension().create(1)]
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        self.assertTrue(verifier.verify(server_hello))
+
+    def test_verify_with_bad_cert_type_selected_by_server(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [1]
+        client_hello.client_version = (3, 3)
+        client_hello.extensions = [ClientCertTypeExtension().create([1])]
+        server_hello = ServerHello()
+        server_hello.cipher_suite = 1
+        server_hello.server_version = (3, 3)
+        server_hello.extensions = [ServerCertTypeExtension().create(0)]
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        with self.assertRaises(TLSIllegalParameterException) as context:
+            verifier.verify(server_hello)
+
+        self.assertTrue('incorrect certificate type' in str(context.exception))

--- a/unit_tests/test_tlslite_verifiers.py
+++ b/unit_tests/test_tlslite_verifiers.py
@@ -1,0 +1,79 @@
+# Copyright (c) 2015, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+        import unittest2 as unittest
+except ImportError:
+        import unittest
+
+from tlslite.verifiers import ServerHelloVerifier
+from tlslite.messages import ClientHello, ServerHello
+from tlslite.constants import CipherSuite, ExtensionType
+from tlslite.extensions import TLSExtension
+from tlslite.errors import TLSIllegalParameterException
+
+class TestServerHelloVerifier(unittest.TestCase):
+    def test___init__(self):
+        verifier = ServerHelloVerifier(None)
+
+        self.assertIsNotNone(verifier)
+
+    def test_verify(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [1]
+        server_hello = ServerHello()
+        server_hello.cipher_suite = 1
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        self.assertTrue(verifier.verify(server_hello))
+
+    def test_verify_with_renegotiation_info_scsv(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = \
+                [1, CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
+
+        server_hello = ServerHello()
+        server_hello.cipher_suite = 1
+        server_hello.extensions = [TLSExtension().create(\
+                ExtensionType.renegotiation_info,
+                bytearray(1))]
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        self.assertTrue(verifier.verify(server_hello))
+
+    def test_verify_abort_with_renegotiation_info_without_scsv(self):
+        client_hello = ClientHello()
+
+        server_hello = ServerHello()
+        server_hello.extensions = [TLSExtension().create(\
+                ExtensionType.renegotiation_info,
+                bytearray(1))]
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        with self.assertRaises(TLSIllegalParameterException) as context:
+            verifier.verify(server_hello)
+
+        self.assertTrue('Extension ID' in str(context.exception))
+
+    def test_verify_with_duplicate_extensions(self):
+        client_hello = ClientHello()
+        client_hello.extensions = [
+                TLSExtension().create(0, bytearray(0))]
+
+        server_hello = ServerHello()
+        server_hello.extensions = [
+                TLSExtension().create(0, bytearray(0)),
+                TLSExtension().create(0, bytearray(1))]
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        with self.assertRaises(TLSIllegalParameterException) as context:
+            verifier.verify(server_hello)
+
+        self.assertTrue('Duplicate extensions' in str(context.exception))

--- a/unit_tests/test_tlslite_verifiers.py
+++ b/unit_tests/test_tlslite_verifiers.py
@@ -194,3 +194,26 @@ class TestServerHelloVerifier(unittest.TestCase):
             verifier.verify(server_hello)
 
         self.assertTrue('incorrect certificate type' in str(context.exception))
+
+    def test_check(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [0]
+        client_hello.client_version = (3, 3)
+        server_hello = ServerHello()
+        server_hello.server_version = (3, 3)
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        self.assertTrue(verifier.check(server_hello))
+
+    def test_check_with_bad_server_hello(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [0]
+        client_hello.client_version = (3, 3)
+        server_hello = ServerHello()
+        server_hello.cipher_suite = 1
+        server_hello.server_version = (3, 3)
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        self.assertFalse(verifier.check(server_hello))

--- a/unit_tests/test_tlslite_verifiers.py
+++ b/unit_tests/test_tlslite_verifiers.py
@@ -77,3 +77,17 @@ class TestServerHelloVerifier(unittest.TestCase):
             verifier.verify(server_hello)
 
         self.assertTrue('Duplicate extensions' in str(context.exception))
+
+    def test_verify_with_wrong_cipher_suite(self):
+        client_hello = ClientHello()
+        client_hello.cipher_suites = [1, 2, 3]
+
+        server_hello = ServerHello()
+        server_hello.cipher_suite = 4
+
+        verifier = ServerHelloVerifier(client_hello)
+
+        with self.assertRaises(TLSIllegalParameterException) as context:
+            verifier.verify(server_hello)
+
+        self.assertTrue('incorrect ciphersuite' in str(context.exception))


### PR DESCRIPTION
Refactor server hello tests so that they are testable in an external class.
 - add checks for duplicate extensions sent by server
 - add checks for extensions sent by server and not advertised by client
 - 100% branch test coverage for all tests
 - fix bug introduced in commit 6568ad9