### PR TITLE
Fix unittests on Python 2.6

### DIFF
--- a/unit_tests/test_tlslite_utils_cryptomath.py
+++ b/unit_tests/test_tlslite_utils_cryptomath.py
@@ -2,7 +2,12 @@
 #
 # See the LICENSE file for legal information regarding use of this file.
 
-import unittest
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 
 from tlslite.utils.cryptomath import isPrime
 


### PR DESCRIPTION
The import for the `tlslite.utils.cryptomath` test is missing a python 2.6 compatible unittest2 library import. That should fix issue #44.