### PR TITLE
[V2] Implement RFC 7366 - Encrypt-then-MAC

### DIFF
--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -109,6 +109,7 @@ def clientTestCmd(argv):
     testConnClient(connection)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.serverName == address[0])
+    assert(connection.etm)
     connection.close()
 
     print("Test 1.a - good X509, SSLv3")
@@ -393,7 +394,18 @@ def clientTestCmd(argv):
     assert(connection.next_proto == b'spdy/2')
     connection.close()
     
-    print('Test 25 - good standard XMLRPC https client')
+    print('Test 25 - no EtM server side')
+    connection = connect()
+    settings = HandshakeSettings()
+    assert settings.useEncryptThenMAC
+    connection.handshakeClientCert(serverName=address[0])
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.etm
+    connection.close()
+
+    print('Test 26 - good standard XMLRPC https client')
     time.sleep(2) # Hack for lack of ability to set timeout here
     address = address[0], address[1]+1
     try:
@@ -408,18 +420,18 @@ def clientTestCmd(argv):
     assert server.add(1,2) == 3
     assert server.pow(2,4) == 16
 
-    print('Test 26 - good tlslite XMLRPC client')
+    print('Test 27 - good tlslite XMLRPC client')
     transport = XMLRPCTransport(ignoreAbruptClose=True)
     server = xmlrpclib.Server('https://%s:%s' % address, transport)
     assert server.add(1,2) == 3
     assert server.pow(2,4) == 16
 
-    print('Test 27 - good XMLRPC ignored protocol')
+    print('Test 28 - good XMLRPC ignored protocol')
     server = xmlrpclib.Server('http://%s:%s' % address, transport)
     assert server.add(1,2) == 3
     assert server.pow(2,4) == 16
-        
-    print("Test 28 - Internet servers test")
+
+    print("Test 29 - Internet servers test")
     try:
         i = IMAP4_TLS("cyrus.andrew.cmu.edu")
         i.login("anonymous", "anonymous@anonymous.net")
@@ -768,7 +780,16 @@ def serverTestCmd(argv):
     testConnServer(connection)
     connection.close()
 
-    print("Tests 25-27 - XMLRPXC server")
+    print('Test 25 - no EtM server side')
+    connection = connect()
+    settings = HandshakeSettings()
+    settings.useEncryptThenMAC = False
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+            settings=settings)
+    testConnServer(connection)
+    connection.close()
+
+    print("Tests 26-28 - XMLRPXC server")
     address = address[0], address[1]+1
     class Server(TLSXMLRPCServer):
 

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -44,6 +44,7 @@ class ExtensionType:    # RFC 6066 / 4366
     server_name = 0     # RFC 6066 / 4366
     srp = 12            # RFC 5054  
     cert_type = 9       # RFC 6091
+    encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
     supports_npn = 13172
     

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -106,6 +106,7 @@ class HandshakeSettings(object):
         self.minVersion = (3,1)
         self.maxVersion = (3,3)
         self.useExperimentalTackExtension = False
+        self.useEncryptThenMAC = True
 
     # Validates the min/max fields, and certificateTypes
     # Filters out unsupported cipherNames and cipherImplementations
@@ -119,6 +120,7 @@ class HandshakeSettings(object):
         other.certificateTypes = self.certificateTypes
         other.minVersion = self.minVersion
         other.maxVersion = self.maxVersion
+        other.useEncryptThenMAC = self.useEncryptThenMAC
 
         if not cipherfactory.tripleDESPresent:
             other.cipherNames = [e for e in self.cipherNames if e != "3des"]

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -108,9 +108,15 @@ class HandshakeSettings(object):
         self.useExperimentalTackExtension = False
         self.useEncryptThenMAC = True
 
-    # Validates the min/max fields, and certificateTypes
-    # Filters out unsupported cipherNames and cipherImplementations
-    def _filter(self):
+    def validate(self):
+        """
+        Validate the settings, filter out unsupported ciphersuites and return
+        a copy of object. Does not modify the original object.
+
+        @rtype: HandshakeSettings
+        @return: a self-consistent copy of settings
+        @raise ValueError: when settings are invalid, insecure or unsupported.
+        """
         other = HandshakeSettings()
         other.minKeySize = self.minKeySize
         other.maxKeySize = self.maxKeySize

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -152,6 +152,8 @@ class HandshakeSettings(object):
             raise ValueError("maxKeySize too small")
         if other.maxKeySize>16384:
             raise ValueError("maxKeySize too large")
+        if other.maxKeySize < other.minKeySize:
+            raise ValueError("maxKeySize smaller than minKeySize")
         for s in other.cipherNames:
             if s not in CIPHER_NAMES:
                 raise ValueError("Unknown cipher name: '%s'" % s)

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -369,7 +369,7 @@ class TLSConnection(TLSRecordLayer):
         # or crypto libraries that were requested        
         if not settings:
             settings = HandshakeSettings()
-        settings = settings._filter()
+        settings = settings.validate()
 
         if clientCertChain:
             if not isinstance(clientCertChain, X509CertChain):
@@ -1122,7 +1122,7 @@ class TLSConnection(TLSRecordLayer):
 
         if not settings:
             settings = HandshakeSettings()
-        settings = settings._filter()
+        settings = settings.validate()
         
         # OK Start exchanging messages
         # ******************************

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -1,0 +1,94 @@
+# Author: Hubert Kario (c) 2014
+# see LICENCE file for legal information regarding use of this file
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from tlslite.handshakesettings import HandshakeSettings
+
+class TestHandshakeSettings(unittest.TestCase):
+    def test___init__(self):
+        hs = HandshakeSettings()
+
+        self.assertIsNotNone(hs)
+
+    def test_validate(self):
+        hs = HandshakeSettings()
+        newHS = hs.validate()
+
+        self.assertIsNotNone(newHS)
+        self.assertIsNot(hs, newHS)
+
+    def test_minKeySize_too_small(self):
+        hs = HandshakeSettings()
+        hs.minKeySize = 511
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_minKeySize_too_large(self):
+        hs = HandshakeSettings()
+        hs.minKeySize = 16385
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_maxKeySize_too_small(self):
+        hs = HandshakeSettings()
+        hs.maxKeySize = 511
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_maxKeySize_too_large(self):
+        hs = HandshakeSettings()
+        hs.maxKeySize = 16385
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_maxKeySize_smaller_than_minKeySize(self):
+        hs = HandshakeSettings()
+        hs.maxKeySize = 1024
+        hs.minKeySize = 2048
+
+        # XXX not raised
+        #with self.assertRaises(ValueError):
+        hs.validate()
+
+    def test_cipherNames_with_unknown_name(self):
+        hs = HandshakeSettings()
+        hs.cipherNames = ["aes256"]
+
+        newHs = hs.validate()
+
+        self.assertEqual(["aes256"], newHs.cipherNames)
+
+    def test_cipherNames_with_unknown_name(self):
+        hs = HandshakeSettings()
+        hs.cipherNames = ["aes256gcm", "aes256"]
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_useEncryptThenMAC(self):
+        hs = HandshakeSettings()
+
+        self.assertTrue(hs.useEncryptThenMAC)
+
+        newHS = hs.validate()
+
+        self.assertTrue(newHS.useEncryptThenMAC)
+
+    def test_useEncryptThenMAC_setting(self):
+        hs = HandshakeSettings()
+        hs.useEncryptThenMAC = False
+
+        self.assertFalse(hs.useEncryptThenMAC)
+
+        newHS = hs.validate()
+        self.assertFalse(newHS.useEncryptThenMAC)

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -56,9 +56,8 @@ class TestHandshakeSettings(unittest.TestCase):
         hs.maxKeySize = 1024
         hs.minKeySize = 2048
 
-        # XXX not raised
-        #with self.assertRaises(ValueError):
-        hs.validate()
+        with self.assertRaises(ValueError):
+            hs.validate()
 
     def test_cipherNames_with_unknown_name(self):
         hs = HandshakeSettings()


### PR DESCRIPTION
Implements the encrypt then MAC mechanism for CBC based cipher suites in TLS. Add some simple tests for HandshakeSettings, fix trivial bug there.

Missing:
- client side check for EtM advertised in server hello together with stream or AEAD cipher (it's incorrect use and it will fail to interoperate but won't report correct errors - I'd rather test it using mechanism introduced in #47)
- ability to force use of EtM (abort connection when server didn't select EtM but did select CBC cipher suite - that will need to wait for AEAD to be actually useful)

Changes from v1:
- reworked "etm decryption" and "etm encryption" patches to better show what is happening, unfortunately the "move MAC-then-encrypt to separate methods" is still rather hard to read, but it's not really possible to make it any better
- rebased on master with fixed tests

Obsoletes #48