### PR TITLE
[v3] Improve CI coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,12 +7,34 @@ python:
   - 3.3
   - 3.4
 
+before_install:
+  - |
+       # workaround https://github.com/travis-ci/travis-ci/issues/2666
+       if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+         PR_FIRST=$(curl -s https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST}.patch | head -1 | grep -o -E '\b[0-9a-f]{40}\b' | tr -d '\n')
+         TRAVIS_COMMIT_RANGE=$PR_FIRST^..$TRAVIS_COMMIT
+       fi
+
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
 
 script:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then unit2 discover; else python -m unittest discover; fi
   - ./setup.py install && make test
+  - echo "Will test commits between $TRAVIS_COMMIT_RANGE:"
+  - git log --oneline --reverse $TRAVIS_COMMIT_RANGE
+  - | 
+      for i in $(git log --pretty=format:%H --reverse $TRAVIS_COMMIT_RANGE); do
+        git checkout $i
+        make clean
+        if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then
+          unit2 discover || exit 1
+        else
+          python -m unittest discover || exit 1
+        fi
+        make test-local || exit 1
+        cd $TRAVIS_BUILD_DIR
+      done
 
 sudo: false
 

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,10 @@ test:
 	cd tests/ && python ./tlstest.py server localhost:4433 . & sleep 1
 	cd tests/ && python ./tlstest.py client localhost:4433 .
 
+test-local:
+	cd tests/ && PYTHONPATH=.. python ./tlstest.py server localhost:4433 . & sleep 1
+	cd tests/ && PYTHONPATH=.. python ./tlstest.py client localhost:4433 .
+
 test-dev:
 ifdef PYTHON2
 	@echo "Running test suite with Python 2"


### PR DESCRIPTION
Run the unit and integration test suites over every patch in pull request, so that `git bisect` will work correctly later.

Changes from v1:
 - run the integration test suite using `make` as the travis environment doesn't seem to be stable enough
 - workaround travis-ci/travis-ci#2666