### PR TITLE
[v2] Try fixing random failures in Travis environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ clean:
 	rm -rf docs
 	rm -rf build
 	rm -f MANIFEST
+	rm -f tests/synchro.fifo
 
 docs:
 	epydoc --html -v --introspect-only -o docs --graph all tlslite

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -85,6 +85,10 @@ def clientTestCmd(argv):
     address = address.split(":")
     address = ( address[0], int(address[1]) )
 
+    #open synchronisation FIFO
+    synchroFileName = os.path.join(dir, "synchro.fifo")
+    synchro = open(synchroFileName, "rb", 0)
+
     def connect():
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if hasattr(sock, 'settimeout'): #It's a python 2.3 feature
@@ -98,12 +102,14 @@ def clientTestCmd(argv):
     badFault = False
 
     print("Test 0 - anonymous handshake")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientAnonymous()
     testConnClient(connection)
     connection.close()
         
     print("Test 1 - good X509 (plus SNI)")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(serverName=address[0])
     testConnClient(connection)
@@ -112,6 +118,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 1.a - good X509, SSLv3")
+    synchro.read(1)
     connection = connect()
     settings = HandshakeSettings()
     settings.minVersion = (3,0)
@@ -122,6 +129,7 @@ def clientTestCmd(argv):
     connection.close()    
 
     print("Test 1.b - good X509, RC4-MD5")
+    synchro.read(1)
     connection = connect()
     settings = HandshakeSettings()
     settings.macNames = ["md5"]
@@ -137,6 +145,7 @@ def clientTestCmd(argv):
         settings.useExperimentalTackExtension = True
 
         print("Test 2.a - good X.509, TACK")
+        synchro.read(1)
         connection = connect()
         connection.handshakeClientCert(settings=settings)
         assert(connection.session.tackExt.tacks[0].getTackId() == "rrted.ptvtl.d2uiq.ox2xe.w4ss3")
@@ -145,6 +154,7 @@ def clientTestCmd(argv):
         connection.close()    
 
         print("Test 2.b - good X.509, TACK unrelated to cert chain")
+        synchro.read(1)
         connection = connect()
         try:
             connection.handshakeClientCert(settings=settings)
@@ -155,6 +165,7 @@ def clientTestCmd(argv):
         connection.close()
 
     print("Test 3 - good SRP")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientSRP("test", "password")
     testConnClient(connection)
@@ -162,6 +173,7 @@ def clientTestCmd(argv):
 
     print("Test 4 - SRP faults")
     for fault in Fault.clientSrpFaults + Fault.genericFaults:
+        synchro.read(1)
         connection = connect()
         connection.fault = fault
         try:
@@ -175,6 +187,7 @@ def clientTestCmd(argv):
     settings = HandshakeSettings()
     settings.minVersion = (3,1)
     settings.maxVersion = (3,1)    
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientSRP("test", "password", settings=settings)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
@@ -183,6 +196,7 @@ def clientTestCmd(argv):
 
     print("Test 7 - X.509 with SRP faults")
     for fault in Fault.clientSrpFaults + Fault.genericFaults:
+        synchro.read(1)
         connection = connect()
         connection.fault = fault
         try:
@@ -194,6 +208,7 @@ def clientTestCmd(argv):
 
     print("Test 11 - X.509 faults")
     for fault in Fault.clientNoAuthFaults + Fault.genericFaults:
+        synchro.read(1)
         connection = connect()
         connection.fault = fault
         try:
@@ -209,6 +224,7 @@ def clientTestCmd(argv):
     s = open(os.path.join(dir, "clientX509Key.pem")).read()
     x509Key = parsePEMKey(s, private=True)
 
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(x509Chain, x509Key)
     testConnClient(connection)
@@ -216,6 +232,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 14.a - good mutual X509, SSLv3")
+    synchro.read(1)
     connection = connect()
     settings = HandshakeSettings()
     settings.minVersion = (3,0)
@@ -227,6 +244,7 @@ def clientTestCmd(argv):
 
     print("Test 15 - mutual X.509 faults")
     for fault in Fault.clientCertFaults + Fault.genericFaults:
+        synchro.read(1)
         connection = connect()
         connection.fault = fault
         try:
@@ -237,6 +255,7 @@ def clientTestCmd(argv):
             badFault = True
 
     print("Test 18 - good SRP, prepare to resume... (plus SNI)")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientSRP("test", "password", serverName=address[0])
     testConnClient(connection)
@@ -244,6 +263,7 @@ def clientTestCmd(argv):
     session = connection.session
 
     print("Test 19 - resumption (plus SNI)")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientSRP("test", "garbage", serverName=address[0], 
                                     session=session)
@@ -251,7 +271,9 @@ def clientTestCmd(argv):
     #Don't close! -- see below
 
     print("Test 20 - invalidated resumption (plus SNI)")
+    synchro.read(1)
     connection.sock.close() #Close the socket without a close_notify!
+    synchro.read(1)
     connection = connect()
     try:
         connection.handshakeClientSRP("test", "garbage", 
@@ -270,7 +292,6 @@ def clientTestCmd(argv):
         timeoutEx = socket.error
     while 1:
         try:
-            time.sleep(2)
             htmlBody = bytearray(open(os.path.join(dir, "index.html")).read(), "utf-8")
             fingerprint = None
             for y in range(2):
@@ -278,6 +299,7 @@ def clientTestCmd(argv):
                 h = HTTPTLSConnection(\
                         address[0], address[1], checker=checker)
                 for x in range(3):
+                    synchro.read(1)
                     h.request("GET", "/index.html")
                     r = h.getresponse()
                     assert(r.status == 200)
@@ -285,7 +307,6 @@ def clientTestCmd(argv):
                     assert(b == htmlBody)
                 fingerprint = h.tlsSession.serverCertChain.getFingerprint()
                 assert(fingerprint)
-            time.sleep(2)
             break
         except timeoutEx:
             print("timeout, retrying...")
@@ -305,6 +326,7 @@ def clientTestCmd(argv):
         for cipher in ["aes128", "aes256", "rc4"]:
 
             print("Test 22:", end=' ')
+            synchro.read(1)
             connection = connect()
 
             settings = HandshakeSettings()
@@ -324,6 +346,7 @@ def clientTestCmd(argv):
                 continue
 
             print("Test 23:", end=' ')
+            synchro.read(1)
             connection = connect()
 
             settings = HandshakeSettings()
@@ -345,6 +368,7 @@ def clientTestCmd(argv):
             connection.close()
     
     print("Test 24.a - Next-Protocol Client Negotiation")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -352,6 +376,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 24.b - Next-Protocol Client Negotiation")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -359,6 +384,7 @@ def clientTestCmd(argv):
     connection.close()
     
     print("Test 24.c - Next-Protocol Client Negotiation")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -366,6 +392,7 @@ def clientTestCmd(argv):
     connection.close()
     
     print("Test 24.d - Next-Protocol Client Negotiation")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/3", b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -373,6 +400,7 @@ def clientTestCmd(argv):
     connection.close()
     
     print("Test 24.e - Next-Protocol Client Negotiation")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/3", b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -380,6 +408,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 24.f - Next-Protocol Client Negotiation")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -387,6 +416,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 24.g - Next-Protocol Client Negotiation")
+    synchro.read(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -394,8 +424,8 @@ def clientTestCmd(argv):
     connection.close()
     
     print('Test 25 - good standard XMLRPC https client')
-    time.sleep(2) # Hack for lack of ability to set timeout here
     address = address[0], address[1]+1
+    synchro.read(1)
     try:
         # python 2.7.9 introduced certificate verification (context option)
         # python 3.4.2 doesn't have it though
@@ -405,18 +435,24 @@ def clientTestCmd(argv):
     except (TypeError, AttributeError):
         server = xmlrpclib.Server('https://%s:%s' % address)
 
+    synchro.read(1)
     assert server.add(1,2) == 3
+    synchro.read(1)
     assert server.pow(2,4) == 16
 
     print('Test 26 - good tlslite XMLRPC client')
     transport = XMLRPCTransport(ignoreAbruptClose=True)
     server = xmlrpclib.Server('https://%s:%s' % address, transport)
+    synchro.read(1)
     assert server.add(1,2) == 3
+    synchro.read(1)
     assert server.pow(2,4) == 16
 
     print('Test 27 - good XMLRPC ignored protocol')
     server = xmlrpclib.Server('http://%s:%s' % address, transport)
+    synchro.read(1)
     assert server.add(1,2) == 3
+    synchro.read(1)
     assert server.pow(2,4) == 16
         
     print("Test 28 - Internet servers test")
@@ -430,6 +466,8 @@ def clientTestCmd(argv):
         print("Test 29: POP3 good")
     except socket.error as e:
         print("Non-critical error: socket error trying to reach internet server: ", e)   
+
+    synchro.close()
 
     if not badFault:
         print("Test succeeded")
@@ -458,11 +496,18 @@ def serverTestCmd(argv):
     address = address.split(":")
     address = ( address[0], int(address[1]) )
 
+    #Create synchronisation FIFO
+    synchroFileName = os.path.join(dir, "synchro.fifo")
+    os.mkfifo(synchroFileName)
+
     #Connect to server
     lsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     lsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     lsock.bind(address)
     lsock.listen(5)
+
+    # following is blocking until the other side doesn't open
+    synchro = open(synchroFileName, "wb", 0)
 
     def connect():
         return TLSConnection(lsock.accept()[0])
@@ -473,12 +518,14 @@ def serverTestCmd(argv):
     x509Key = parsePEMKey(s, private=True)
 
     print("Test 0 - Anonymous server handshake")
+    synchro.write(b"R")
     connection = connect()
     connection.handshakeServer(anon=True)
     testConnServer(connection)    
     connection.close() 
     
     print("Test 1 - good X.509")
+    synchro.write(b"R")
     connection = connect()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key)
     assert(connection.session.serverName == address[0])    
@@ -486,6 +533,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 1.a - good X.509, SSL v3")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     settings.minVersion = (3,0)
@@ -495,6 +543,7 @@ def serverTestCmd(argv):
     connection.close()            
 
     print("Test 1.b - good X.509, RC4-MD5")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     settings.macNames = ["sha", "md5"]
@@ -511,6 +560,7 @@ def serverTestCmd(argv):
         settings.useExperimentalTackExtension = True
 
         print("Test 2.a - good X.509, TACK")
+        synchro.write(b"R")
         connection = connect()
         connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
             tacks=[tack], activationFlags=1, settings=settings)
@@ -518,6 +568,7 @@ def serverTestCmd(argv):
         connection.close()        
 
         print("Test 2.b - good X.509, TACK unrelated to cert chain")
+        synchro.write(b"R")
         connection = connect()
         try:
             connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
@@ -533,6 +584,7 @@ def serverTestCmd(argv):
     entry = VerifierDB.makeVerifier("test", "password", 1536)
     verifierDB["test"] = entry
 
+    synchro.write(b"R")
     connection = connect()
     connection.handshakeServer(verifierDB=verifierDB)
     testConnServer(connection)
@@ -540,6 +592,7 @@ def serverTestCmd(argv):
 
     print("Test 4 - SRP faults")
     for fault in Fault.clientSrpFaults + Fault.genericFaults:
+        synchro.write(b"R")
         connection = connect()
         connection.fault = fault
         try:
@@ -550,6 +603,7 @@ def serverTestCmd(argv):
         connection.close()
 
     print("Test 6 - good SRP: with X.509 cert")
+    synchro.write(b"R")
     connection = connect()
     connection.handshakeServer(verifierDB=verifierDB, \
                                certChain=x509Chain, privateKey=x509Key)
@@ -558,6 +612,7 @@ def serverTestCmd(argv):
 
     print("Test 7 - X.509 with SRP faults")
     for fault in Fault.clientSrpFaults + Fault.genericFaults:
+        synchro.write(b"R")
         connection = connect()
         connection.fault = fault
         try:
@@ -570,6 +625,7 @@ def serverTestCmd(argv):
 
     print("Test 11 - X.509 faults")
     for fault in Fault.clientNoAuthFaults + Fault.genericFaults:
+        synchro.write(b"R")
         connection = connect()
         connection.fault = fault
         try:
@@ -580,6 +636,7 @@ def serverTestCmd(argv):
         connection.close()
 
     print("Test 14 - good mutual X.509")
+    synchro.write(b"R")
     connection = connect()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, reqCert=True)
     testConnServer(connection)
@@ -587,6 +644,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 14a - good mutual X.509, SSLv3")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     settings.minVersion = (3,0)
@@ -598,6 +656,7 @@ def serverTestCmd(argv):
 
     print("Test 15 - mutual X.509 faults")
     for fault in Fault.clientCertFaults + Fault.genericFaults:
+        synchro.write(b"R")
         connection = connect()
         connection.fault = fault
         try:
@@ -608,6 +667,7 @@ def serverTestCmd(argv):
         connection.close()
 
     print("Test 18 - good SRP, prepare to resume")
+    synchro.write(b"R")
     sessionCache = SessionCache()
     connection = connect()
     connection.handshakeServer(verifierDB=verifierDB, sessionCache=sessionCache)
@@ -616,6 +676,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 19 - resumption")
+    synchro.write(b"R")
     connection = connect()
     connection.handshakeServer(verifierDB=verifierDB, sessionCache=sessionCache)
     assert(connection.session.serverName == address[0])
@@ -623,11 +684,13 @@ def serverTestCmd(argv):
     #Don't close! -- see next test
 
     print("Test 20 - invalidated resumption")
+    synchro.write(b"R")
     try:
         connection.read(min=1, max=1)
         assert() #Client is going to close the socket without a close_notify
     except TLSAbruptCloseError as e:
         pass
+    synchro.write(b"R")
     connection = connect()
     try:
         connection.handshakeServer(verifierDB=verifierDB, sessionCache=sessionCache)
@@ -656,6 +719,7 @@ def serverTestCmd(argv):
     address = address[0], address[1]+1
     httpd = MyHTTPServer(address, SimpleHTTPRequestHandler)
     for x in range(6):
+        synchro.write(b"R")
         httpd.handle_request()
     httpd.server_close()
     cd = os.chdir(cd)
@@ -679,6 +743,7 @@ def serverTestCmd(argv):
         for cipher in ["aes128", "aes256", "rc4"]:
 
             print("Test 22:", end=' ')
+            synchro.write(b"R")
             connection = connect()
 
             settings = HandshakeSettings()
@@ -698,6 +763,7 @@ def serverTestCmd(argv):
                 continue
 
             print("Test 23:", end=' ')
+            synchro.write(b"R")
             connection = connect()
 
             settings = HandshakeSettings()
@@ -713,6 +779,7 @@ def serverTestCmd(argv):
             connection.close()
 
     print("Test 24.a - Next-Protocol Server Negotiation")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -721,6 +788,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 24.b - Next-Protocol Server Negotiation")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -729,6 +797,7 @@ def serverTestCmd(argv):
     connection.close()
     
     print("Test 24.c - Next-Protocol Server Negotiation")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -737,6 +806,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 24.d - Next-Protocol Server Negotiation")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -745,6 +815,7 @@ def serverTestCmd(argv):
     connection.close()
     
     print("Test 24.e - Next-Protocol Server Negotiation")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -753,6 +824,7 @@ def serverTestCmd(argv):
     connection.close()
     
     print("Test 24.f - Next-Protocol Server Negotiation")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -761,6 +833,7 @@ def serverTestCmd(argv):
     connection.close()
     
     print("Test 24.g - Next-Protocol Server Negotiation")
+    synchro.write(b"R")
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -789,10 +862,15 @@ def serverTestCmd(argv):
 
     server = Server(address)
     server.register_instance(MyFuncs())
+    synchro.write(b"R")
     #sa = server.socket.getsockname()
     #print "Serving HTTPS on", sa[0], "port", sa[1]
     for i in range(6):
+        synchro.write(b"R")
         server.handle_request()
+
+    os.remove(synchroFileName)
+    synchro.close()
 
     print("Test succeeded")
 


### PR DESCRIPTION
because Travis-CI servers are sometimes under heavy load, the
synchronisation using `time.sleep(2)` is not deterministic,
change it to use Unix FIFO

Server writes a single character (that's non-blocking) to FIFO
when it has set up and is able to handle requests from client.
The client tries to read a single character (that's blocking)
before trying to connect to server.

Changes from v1:
 - python3 compatibility
 - clean up the fifo in `make clean`