### PR TITLE
[v3] Try fixing random failures in Travis environment

### DIFF
--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -85,6 +85,11 @@ def clientTestCmd(argv):
     address = address.split(":")
     address = ( address[0], int(address[1]) )
 
+    #open synchronisation FIFO
+    synchro = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    synchro.settimeout(5)
+    synchro.connect((address[0], address[1]-1))
+
     def connect():
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         if hasattr(sock, 'settimeout'): #It's a python 2.3 feature
@@ -98,12 +103,14 @@ def clientTestCmd(argv):
     badFault = False
 
     print("Test 0 - anonymous handshake")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientAnonymous()
     testConnClient(connection)
     connection.close()
         
     print("Test 1 - good X509 (plus SNI)")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(serverName=address[0])
     testConnClient(connection)
@@ -112,6 +119,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 1.a - good X509, SSLv3")
+    synchro.recv(1)
     connection = connect()
     settings = HandshakeSettings()
     settings.minVersion = (3,0)
@@ -122,6 +130,7 @@ def clientTestCmd(argv):
     connection.close()    
 
     print("Test 1.b - good X509, RC4-MD5")
+    synchro.recv(1)
     connection = connect()
     settings = HandshakeSettings()
     settings.macNames = ["md5"]
@@ -137,6 +146,7 @@ def clientTestCmd(argv):
         settings.useExperimentalTackExtension = True
 
         print("Test 2.a - good X.509, TACK")
+        synchro.recv(1)
         connection = connect()
         connection.handshakeClientCert(settings=settings)
         assert(connection.session.tackExt.tacks[0].getTackId() == "rrted.ptvtl.d2uiq.ox2xe.w4ss3")
@@ -145,6 +155,7 @@ def clientTestCmd(argv):
         connection.close()    
 
         print("Test 2.b - good X.509, TACK unrelated to cert chain")
+        synchro.recv(1)
         connection = connect()
         try:
             connection.handshakeClientCert(settings=settings)
@@ -155,6 +166,7 @@ def clientTestCmd(argv):
         connection.close()
 
     print("Test 3 - good SRP")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientSRP("test", "password")
     testConnClient(connection)
@@ -162,6 +174,7 @@ def clientTestCmd(argv):
 
     print("Test 4 - SRP faults")
     for fault in Fault.clientSrpFaults + Fault.genericFaults:
+        synchro.recv(1)
         connection = connect()
         connection.fault = fault
         try:
@@ -175,6 +188,7 @@ def clientTestCmd(argv):
     settings = HandshakeSettings()
     settings.minVersion = (3,1)
     settings.maxVersion = (3,1)    
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientSRP("test", "password", settings=settings)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
@@ -183,6 +197,7 @@ def clientTestCmd(argv):
 
     print("Test 7 - X.509 with SRP faults")
     for fault in Fault.clientSrpFaults + Fault.genericFaults:
+        synchro.recv(1)
         connection = connect()
         connection.fault = fault
         try:
@@ -194,6 +209,7 @@ def clientTestCmd(argv):
 
     print("Test 11 - X.509 faults")
     for fault in Fault.clientNoAuthFaults + Fault.genericFaults:
+        synchro.recv(1)
         connection = connect()
         connection.fault = fault
         try:
@@ -209,6 +225,7 @@ def clientTestCmd(argv):
     s = open(os.path.join(dir, "clientX509Key.pem")).read()
     x509Key = parsePEMKey(s, private=True)
 
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(x509Chain, x509Key)
     testConnClient(connection)
@@ -216,6 +233,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 14.a - good mutual X509, SSLv3")
+    synchro.recv(1)
     connection = connect()
     settings = HandshakeSettings()
     settings.minVersion = (3,0)
@@ -227,6 +245,7 @@ def clientTestCmd(argv):
 
     print("Test 15 - mutual X.509 faults")
     for fault in Fault.clientCertFaults + Fault.genericFaults:
+        synchro.recv(1)
         connection = connect()
         connection.fault = fault
         try:
@@ -237,6 +256,7 @@ def clientTestCmd(argv):
             badFault = True
 
     print("Test 18 - good SRP, prepare to resume... (plus SNI)")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientSRP("test", "password", serverName=address[0])
     testConnClient(connection)
@@ -244,6 +264,7 @@ def clientTestCmd(argv):
     session = connection.session
 
     print("Test 19 - resumption (plus SNI)")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientSRP("test", "garbage", serverName=address[0], 
                                     session=session)
@@ -251,7 +272,9 @@ def clientTestCmd(argv):
     #Don't close! -- see below
 
     print("Test 20 - invalidated resumption (plus SNI)")
+    synchro.recv(1)
     connection.sock.close() #Close the socket without a close_notify!
+    synchro.recv(1)
     connection = connect()
     try:
         connection.handshakeClientSRP("test", "garbage", 
@@ -270,7 +293,6 @@ def clientTestCmd(argv):
         timeoutEx = socket.error
     while 1:
         try:
-            time.sleep(2)
             htmlBody = bytearray(open(os.path.join(dir, "index.html")).read(), "utf-8")
             fingerprint = None
             for y in range(2):
@@ -278,6 +300,7 @@ def clientTestCmd(argv):
                 h = HTTPTLSConnection(\
                         address[0], address[1], checker=checker)
                 for x in range(3):
+                    synchro.recv(1)
                     h.request("GET", "/index.html")
                     r = h.getresponse()
                     assert(r.status == 200)
@@ -285,7 +308,6 @@ def clientTestCmd(argv):
                     assert(b == htmlBody)
                 fingerprint = h.tlsSession.serverCertChain.getFingerprint()
                 assert(fingerprint)
-            time.sleep(2)
             break
         except timeoutEx:
             print("timeout, retrying...")
@@ -305,6 +327,7 @@ def clientTestCmd(argv):
         for cipher in ["aes128", "aes256", "rc4"]:
 
             print("Test 22:", end=' ')
+            synchro.recv(1)
             connection = connect()
 
             settings = HandshakeSettings()
@@ -324,6 +347,7 @@ def clientTestCmd(argv):
                 continue
 
             print("Test 23:", end=' ')
+            synchro.recv(1)
             connection = connect()
 
             settings = HandshakeSettings()
@@ -345,6 +369,7 @@ def clientTestCmd(argv):
             connection.close()
     
     print("Test 24.a - Next-Protocol Client Negotiation")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -352,6 +377,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 24.b - Next-Protocol Client Negotiation")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -359,6 +385,7 @@ def clientTestCmd(argv):
     connection.close()
     
     print("Test 24.c - Next-Protocol Client Negotiation")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -366,6 +393,7 @@ def clientTestCmd(argv):
     connection.close()
     
     print("Test 24.d - Next-Protocol Client Negotiation")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/3", b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -373,6 +401,7 @@ def clientTestCmd(argv):
     connection.close()
     
     print("Test 24.e - Next-Protocol Client Negotiation")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/3", b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -380,6 +409,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 24.f - Next-Protocol Client Negotiation")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -387,6 +417,7 @@ def clientTestCmd(argv):
     connection.close()
 
     print("Test 24.g - Next-Protocol Client Negotiation")
+    synchro.recv(1)
     connection = connect()
     connection.handshakeClientCert(nextProtos=[b"spdy/2", b"http/1.1"])
     #print("  Next-Protocol Negotiated: %s" % connection.next_proto)
@@ -394,8 +425,8 @@ def clientTestCmd(argv):
     connection.close()
     
     print('Test 25 - good standard XMLRPC https client')
-    time.sleep(2) # Hack for lack of ability to set timeout here
     address = address[0], address[1]+1
+    synchro.recv(1)
     try:
         # python 2.7.9 introduced certificate verification (context option)
         # python 3.4.2 doesn't have it though
@@ -405,18 +436,24 @@ def clientTestCmd(argv):
     except (TypeError, AttributeError):
         server = xmlrpclib.Server('https://%s:%s' % address)
 
+    synchro.recv(1)
     assert server.add(1,2) == 3
+    synchro.recv(1)
     assert server.pow(2,4) == 16
 
     print('Test 26 - good tlslite XMLRPC client')
     transport = XMLRPCTransport(ignoreAbruptClose=True)
     server = xmlrpclib.Server('https://%s:%s' % address, transport)
+    synchro.recv(1)
     assert server.add(1,2) == 3
+    synchro.recv(1)
     assert server.pow(2,4) == 16
 
     print('Test 27 - good XMLRPC ignored protocol')
     server = xmlrpclib.Server('http://%s:%s' % address, transport)
+    synchro.recv(1)
     assert server.add(1,2) == 3
+    synchro.recv(1)
     assert server.pow(2,4) == 16
         
     print("Test 28 - Internet servers test")
@@ -430,6 +467,8 @@ def clientTestCmd(argv):
         print("Test 29: POP3 good")
     except socket.error as e:
         print("Non-critical error: socket error trying to reach internet server: ", e)   
+
+    synchro.close()
 
     if not badFault:
         print("Test succeeded")
@@ -458,11 +497,20 @@ def serverTestCmd(argv):
     address = address.split(":")
     address = ( address[0], int(address[1]) )
 
+    #Create synchronisation FIFO
+    synchroSocket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    synchroSocket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    synchroSocket.bind((address[0], address[1]-1))
+    synchroSocket.listen(2)
+
     #Connect to server
     lsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     lsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     lsock.bind(address)
     lsock.listen(5)
+
+    # following is blocking until the other side doesn't open
+    synchro = synchroSocket.accept()[0]
 
     def connect():
         return TLSConnection(lsock.accept()[0])
@@ -473,12 +521,14 @@ def serverTestCmd(argv):
     x509Key = parsePEMKey(s, private=True)
 
     print("Test 0 - Anonymous server handshake")
+    synchro.send(b'R')
     connection = connect()
     connection.handshakeServer(anon=True)
     testConnServer(connection)    
     connection.close() 
     
     print("Test 1 - good X.509")
+    synchro.send(b'R')
     connection = connect()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key)
     assert(connection.session.serverName == address[0])    
@@ -486,6 +536,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 1.a - good X.509, SSL v3")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     settings.minVersion = (3,0)
@@ -495,6 +546,7 @@ def serverTestCmd(argv):
     connection.close()            
 
     print("Test 1.b - good X.509, RC4-MD5")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     settings.macNames = ["sha", "md5"]
@@ -511,6 +563,7 @@ def serverTestCmd(argv):
         settings.useExperimentalTackExtension = True
 
         print("Test 2.a - good X.509, TACK")
+        synchro.send(b'R')
         connection = connect()
         connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
             tacks=[tack], activationFlags=1, settings=settings)
@@ -518,6 +571,7 @@ def serverTestCmd(argv):
         connection.close()        
 
         print("Test 2.b - good X.509, TACK unrelated to cert chain")
+        synchro.send(b'R')
         connection = connect()
         try:
             connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
@@ -533,6 +587,7 @@ def serverTestCmd(argv):
     entry = VerifierDB.makeVerifier("test", "password", 1536)
     verifierDB["test"] = entry
 
+    synchro.send(b'R')
     connection = connect()
     connection.handshakeServer(verifierDB=verifierDB)
     testConnServer(connection)
@@ -540,6 +595,7 @@ def serverTestCmd(argv):
 
     print("Test 4 - SRP faults")
     for fault in Fault.clientSrpFaults + Fault.genericFaults:
+        synchro.send(b'R')
         connection = connect()
         connection.fault = fault
         try:
@@ -550,6 +606,7 @@ def serverTestCmd(argv):
         connection.close()
 
     print("Test 6 - good SRP: with X.509 cert")
+    synchro.send(b'R')
     connection = connect()
     connection.handshakeServer(verifierDB=verifierDB, \
                                certChain=x509Chain, privateKey=x509Key)
@@ -558,6 +615,7 @@ def serverTestCmd(argv):
 
     print("Test 7 - X.509 with SRP faults")
     for fault in Fault.clientSrpFaults + Fault.genericFaults:
+        synchro.send(b'R')
         connection = connect()
         connection.fault = fault
         try:
@@ -570,6 +628,7 @@ def serverTestCmd(argv):
 
     print("Test 11 - X.509 faults")
     for fault in Fault.clientNoAuthFaults + Fault.genericFaults:
+        synchro.send(b'R')
         connection = connect()
         connection.fault = fault
         try:
@@ -580,6 +639,7 @@ def serverTestCmd(argv):
         connection.close()
 
     print("Test 14 - good mutual X.509")
+    synchro.send(b'R')
     connection = connect()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, reqCert=True)
     testConnServer(connection)
@@ -587,6 +647,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 14a - good mutual X.509, SSLv3")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     settings.minVersion = (3,0)
@@ -598,6 +659,7 @@ def serverTestCmd(argv):
 
     print("Test 15 - mutual X.509 faults")
     for fault in Fault.clientCertFaults + Fault.genericFaults:
+        synchro.send(b'R')
         connection = connect()
         connection.fault = fault
         try:
@@ -608,6 +670,7 @@ def serverTestCmd(argv):
         connection.close()
 
     print("Test 18 - good SRP, prepare to resume")
+    synchro.send(b'R')
     sessionCache = SessionCache()
     connection = connect()
     connection.handshakeServer(verifierDB=verifierDB, sessionCache=sessionCache)
@@ -616,6 +679,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 19 - resumption")
+    synchro.send(b'R')
     connection = connect()
     connection.handshakeServer(verifierDB=verifierDB, sessionCache=sessionCache)
     assert(connection.session.serverName == address[0])
@@ -623,11 +687,13 @@ def serverTestCmd(argv):
     #Don't close! -- see next test
 
     print("Test 20 - invalidated resumption")
+    synchro.send(b'R')
     try:
         connection.read(min=1, max=1)
         assert() #Client is going to close the socket without a close_notify
     except TLSAbruptCloseError as e:
         pass
+    synchro.send(b'R')
     connection = connect()
     try:
         connection.handshakeServer(verifierDB=verifierDB, sessionCache=sessionCache)
@@ -656,6 +722,7 @@ def serverTestCmd(argv):
     address = address[0], address[1]+1
     httpd = MyHTTPServer(address, SimpleHTTPRequestHandler)
     for x in range(6):
+        synchro.send(b'R')
         httpd.handle_request()
     httpd.server_close()
     cd = os.chdir(cd)
@@ -679,6 +746,7 @@ def serverTestCmd(argv):
         for cipher in ["aes128", "aes256", "rc4"]:
 
             print("Test 22:", end=' ')
+            synchro.send(b'R')
             connection = connect()
 
             settings = HandshakeSettings()
@@ -698,6 +766,7 @@ def serverTestCmd(argv):
                 continue
 
             print("Test 23:", end=' ')
+            synchro.send(b'R')
             connection = connect()
 
             settings = HandshakeSettings()
@@ -713,6 +782,7 @@ def serverTestCmd(argv):
             connection.close()
 
     print("Test 24.a - Next-Protocol Server Negotiation")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -721,6 +791,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 24.b - Next-Protocol Server Negotiation")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -729,6 +800,7 @@ def serverTestCmd(argv):
     connection.close()
     
     print("Test 24.c - Next-Protocol Server Negotiation")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -737,6 +809,7 @@ def serverTestCmd(argv):
     connection.close()
 
     print("Test 24.d - Next-Protocol Server Negotiation")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -745,6 +818,7 @@ def serverTestCmd(argv):
     connection.close()
     
     print("Test 24.e - Next-Protocol Server Negotiation")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -753,6 +827,7 @@ def serverTestCmd(argv):
     connection.close()
     
     print("Test 24.f - Next-Protocol Server Negotiation")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -761,6 +836,7 @@ def serverTestCmd(argv):
     connection.close()
     
     print("Test 24.g - Next-Protocol Server Negotiation")
+    synchro.send(b'R')
     connection = connect()
     settings = HandshakeSettings()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key, 
@@ -789,10 +865,15 @@ def serverTestCmd(argv):
 
     server = Server(address)
     server.register_instance(MyFuncs())
+    synchro.send(b'R')
     #sa = server.socket.getsockname()
     #print "Serving HTTPS on", sa[0], "port", sa[1]
     for i in range(6):
+        synchro.send(b'R')
         server.handle_request()
+
+    synchro.close()
+    synchroSocket.close()
 
     print("Test succeeded")
 


### PR DESCRIPTION
because Travis-CI servers are sometimes under heavy load, the
synchronisation using `time.sleep(2)` is not deterministic,
change it to use extra socket for synchronisation

Server writes a single character (that's non-blocking) to connection
when it has set up and is able to handle requests from client.
The client tries to read a single character (that's blocking)
before trying to connect to server.

Changes from v2:
 - use socket instead FIFO so that tests are cross-platform

Changes from v1:
  -  python3 compatibility
  -  clean up the fifo in make clean