### PR TITLE
[v3] Implement RFC 7366 - Encrypt-then-MAC

### DIFF
--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -116,6 +116,7 @@ def clientTestCmd(argv):
     testConnClient(connection)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.serverName == address[0])
+    assert(connection.etm)
     connection.close()
 
     print("Test 1.a - good X509, SSLv3")
@@ -424,7 +425,19 @@ def clientTestCmd(argv):
     assert(connection.next_proto == b'spdy/2')
     connection.close()
     
-    print('Test 25 - good standard XMLRPC https client')
+    print('Test 25 - no EtM server side')
+    synchro.recv(1)
+    connection = connect()
+    settings = HandshakeSettings()
+    assert settings.useEncryptThenMAC
+    connection.handshakeClientCert(serverName=address[0])
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.etm
+    connection.close()
+
+    print('Test 26 - good standard XMLRPC https client')
     address = address[0], address[1]+1
     synchro.recv(1)
     try:
@@ -441,7 +454,7 @@ def clientTestCmd(argv):
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
-    print('Test 26 - good tlslite XMLRPC client')
+    print('Test 27 - good tlslite XMLRPC client')
     transport = XMLRPCTransport(ignoreAbruptClose=True)
     server = xmlrpclib.Server('https://%s:%s' % address, transport)
     synchro.recv(1)
@@ -449,14 +462,14 @@ def clientTestCmd(argv):
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
-    print('Test 27 - good XMLRPC ignored protocol')
+    print('Test 28 - good XMLRPC ignored protocol')
     server = xmlrpclib.Server('http://%s:%s' % address, transport)
     synchro.recv(1)
     assert server.add(1,2) == 3
     synchro.recv(1)
     assert server.pow(2,4) == 16
-        
-    print("Test 28 - Internet servers test")
+
+    print("Test 29 - Internet servers test")
     try:
         i = IMAP4_TLS("cyrus.andrew.cmu.edu")
         i.login("anonymous", "anonymous@anonymous.net")
@@ -844,7 +857,17 @@ def serverTestCmd(argv):
     testConnServer(connection)
     connection.close()
 
-    print("Tests 25-27 - XMLRPXC server")
+    print('Test 25 - no EtM server side')
+    synchro.send(b'R')
+    connection = connect()
+    settings = HandshakeSettings()
+    settings.useEncryptThenMAC = False
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+            settings=settings)
+    testConnServer(connection)
+    connection.close()
+
+    print("Tests 26-28 - XMLRPXC server")
     address = address[0], address[1]+1
     class Server(TLSXMLRPCServer):
 

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -44,6 +44,7 @@ class ExtensionType:    # RFC 6066 / 4366
     server_name = 0     # RFC 6066 / 4366
     srp = 12            # RFC 5054  
     cert_type = 9       # RFC 6091
+    encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
     supports_npn = 13172
     

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -106,6 +106,7 @@ class HandshakeSettings(object):
         self.minVersion = (3,1)
         self.maxVersion = (3,3)
         self.useExperimentalTackExtension = False
+        self.useEncryptThenMAC = True
 
     # Validates the min/max fields, and certificateTypes
     # Filters out unsupported cipherNames and cipherImplementations
@@ -119,6 +120,7 @@ class HandshakeSettings(object):
         other.certificateTypes = self.certificateTypes
         other.minVersion = self.minVersion
         other.maxVersion = self.maxVersion
+        other.useEncryptThenMAC = self.useEncryptThenMAC
 
         if not cipherfactory.tripleDESPresent:
             other.cipherNames = [e for e in self.cipherNames if e != "3des"]

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -108,9 +108,15 @@ class HandshakeSettings(object):
         self.useExperimentalTackExtension = False
         self.useEncryptThenMAC = True
 
-    # Validates the min/max fields, and certificateTypes
-    # Filters out unsupported cipherNames and cipherImplementations
-    def _filter(self):
+    def validate(self):
+        """
+        Validate the settings, filter out unsupported ciphersuites and return
+        a copy of object. Does not modify the original object.
+
+        @rtype: HandshakeSettings
+        @return: a self-consistent copy of settings
+        @raise ValueError: when settings are invalid, insecure or unsupported.
+        """
         other = HandshakeSettings()
         other.minKeySize = self.minKeySize
         other.maxKeySize = self.maxKeySize

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -152,6 +152,8 @@ class HandshakeSettings(object):
             raise ValueError("maxKeySize too small")
         if other.maxKeySize>16384:
             raise ValueError("maxKeySize too large")
+        if other.maxKeySize < other.minKeySize:
+            raise ValueError("maxKeySize smaller than minKeySize")
         for s in other.cipherNames:
             if s not in CIPHER_NAMES:
                 raise ValueError("Unknown cipher name: '%s'" % s)

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -369,7 +369,7 @@ class TLSConnection(TLSRecordLayer):
         # or crypto libraries that were requested        
         if not settings:
             settings = HandshakeSettings()
-        settings = settings._filter()
+        settings = settings.validate()
 
         if clientCertChain:
             if not isinstance(clientCertChain, X509CertChain):
@@ -1124,7 +1124,7 @@ class TLSConnection(TLSRecordLayer):
 
         if not settings:
             settings = HandshakeSettings()
-        settings = settings._filter()
+        settings = settings.validate()
         
         # OK Start exchanging messages
         # ******************************

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -399,15 +399,23 @@ class TLSConnection(TLSRecordLayer):
         #We'll use this for the ClientHello, and if an error occurs
         #parsing the Server Hello, we'll use this version for the response
         self.version = settings.maxVersion
+
+        if settings.useEncryptThenMAC:
+            extensions = [TLSExtension().create(ExtensionType.encrypt_then_mac,
+                                                bytearray(0))]
+        else:
+            extensions = None
         
         # OK Start sending messages!
         # *****************************
 
         # Send the ClientHello.
         for result in self._clientSendClientHello(settings, session, 
-                                        srpUsername, srpParams, certParams,
-                                        anonParams, serverName, nextProtos,
-                                        reqTack):
+                                                  srpUsername, srpParams,
+                                                  certParams, anonParams,
+                                                  serverName, nextProtos,
+                                                  reqTack,
+                                                  extensions=extensions):
             if result in (0,1): yield result
             else: break
         clientHello = result
@@ -422,6 +430,10 @@ class TLSConnection(TLSRecordLayer):
         # Choose a matching Next Protocol from server list against ours
         # (string or None)
         nextProto = self._clientSelectNextProto(nextProtos, serverHello)
+
+        # check if server supports encrypt_then_mac
+        if serverHello.getExtension(ExtensionType.encrypt_then_mac):
+            self.etm = True
 
         #If the server elected to resume the session, it is handled here.
         for result in self._clientResume(session, serverHello, 
@@ -493,8 +505,9 @@ class TLSConnection(TLSRecordLayer):
 
 
     def _clientSendClientHello(self, settings, session, srpUsername,
-                                srpParams, certParams, anonParams, 
-                                serverName, nextProtos, reqTack):
+                               srpParams, certParams, anonParams,
+                               serverName, nextProtos, reqTack,
+                               extensions=None):
         #Initialize acceptable ciphersuites
         cipherSuites = [CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV]
         if srpParams:
@@ -523,7 +536,8 @@ class TLSConnection(TLSRecordLayer):
                                    certificateTypes, 
                                    session.srpUsername,
                                    reqTack, nextProtos is not None,
-                                   session.serverName)
+                                   session.serverName,
+                                   extensions=extensions)
 
         #Or send ClientHello (without)
         else:
@@ -532,8 +546,9 @@ class TLSConnection(TLSRecordLayer):
                                bytearray(0), cipherSuites,
                                certificateTypes, 
                                srpUsername,
-                               reqTack, nextProtos is not None, 
-                               serverName)
+                               reqTack, nextProtos is not None,
+                               serverName,
+                               extensions=extensions)
         for result in self._sendMsg(clientHello):
             yield result
         yield clientHello

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -1160,10 +1160,22 @@ class TLSConnection(TLSRecordLayer):
             tackExt = TackExtension.create(tacks, activationFlags)
         else:
             tackExt = None
+
+        # prepare encrypt then mac if required
+        if settings.useEncryptThenMAC and\
+                clientHello.getExtension(ExtensionType.encrypt_then_mac) and\
+                not cipherSuite in [CipherSuite.TLS_RSA_WITH_RC4_128_SHA,\
+                CipherSuite.TLS_RSA_WITH_RC4_128_MD5]:
+            extensions = [TLSExtension().create(ExtensionType.encrypt_then_mac,
+                                                bytearray(0))]
+            self.etm = True
+        else:
+            extensions = None
+
         serverHello = ServerHello()
-        serverHello.create(self.version, getRandomBytes(32), sessionID, \
-                            cipherSuite, CertificateType.x509, tackExt,
-                            nextProtos)
+        serverHello.create(self.version, getRandomBytes(32), sessionID,
+                           cipherSuite, CertificateType.x509, tackExt,
+                           nextProtos, extensions=extensions)
 
         # Perform the SRP key exchange
         clientCertChain = None

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -96,6 +96,10 @@ class TLSRecordLayer(object):
     attacker truncating the connection, and only if necessary to avoid
     spurious errors.  The default is False.
 
+    @type etm: bool
+    @ivar etm: if the record layer uses encrypt-then-mac construct defined
+    in RFC 7366 (read only)
+
     @sort: __init__, read, readAsync, write, writeAsync, close, closeAsync,
     getCipherImplementation, getCipherName
     """
@@ -148,6 +152,9 @@ class TLSRecordLayer(object):
 
         #Fault we will induce, for testing purposes
         self.fault = None
+
+        #Whatever to do Encrypt and MAC or MAC and Encrypt
+        self.etm = False
 
     def clearReadBuffer(self):
         self._readBuffer = b''
@@ -966,6 +973,73 @@ class TLSRecordLayer(object):
             self._handshakeBuffer = self._handshakeBuffer[1:]
             yield (recordHeader, Parser(b))
 
+    def _decryptRecordWithEtM(self, recordType, b):
+        # check MAC
+        macLength = self._readState.macContext.digest_size
+        if len(b) < macLength:
+            for result in self._sendError(AlertDescription.bad_record_mac,
+                                          "MAC failure (truncated data)"):
+                yield result
+
+        checkBytes = b[-macLength:]
+        b = b[:-macLength]
+
+        seqnumBytes = self._readState.getSeqNumBytes()
+        mac = self._readState.macContext.copy()
+        mac.update(compatHMAC(seqnumBytes))
+        mac.update(compatHMAC(bytearray([recordType])))
+        mac.update(compatHMAC(bytearray([self.version[0]])))
+        mac.update(compatHMAC(bytearray([self.version[1]])))
+        mac.update(compatHMAC(bytearray([len(b)//256])))
+        mac.update(compatHMAC(bytearray([len(b)%256])))
+        mac.update(compatHMAC(b))
+
+        macBytes = bytearray(mac.digest())
+        if macBytes != checkBytes:
+            for result in self._sendError(AlertDescription.bad_record_mac,
+                                          "MAC failure (mismatched data)"):
+                yield result
+
+        # decrypt
+        blockLength = self._readState.encContext.block_size
+        if len(b) % blockLength != 0:
+            for result in self._sendError(AlertDescription.decryption_failed,
+                                          "Encrypted data must be multiple of "\
+                                          "blocksize"):
+                yield result
+
+        b = self._readState.encContext.decrypt(b)
+        if self.version >= (3, 2): # remove explicit IV
+            b = b[self._readState.encContext.block_size:]
+
+        # Check padding
+        paddingGood = True
+        paddingLength = b[-1]
+        if (paddingLength+1) > len(b):
+            paddingGood = False
+            totalPaddingLength = 0
+        else:
+            if self.version == (3, 0):
+                totalPaddingLength = paddingLength+1
+            else:
+                totalPaddingLength = paddingLength+1
+                paddingBytes = b[-totalPaddingLength:-1]
+                for byte in paddingBytes:
+                    if byte != paddingLength:
+                        paddingGood = False
+                        totalPaddingLength = 0
+
+        if not paddingGood:
+            for result in self._sendError(AlertDescription.decryption_failed,
+                                          "Encrypted data does not have valid "\
+                                          "padding"):
+                yield result
+
+        # Remove padding
+        b = b[:-totalPaddingLength]
+
+        yield b
+
     def _decryptRecordWithMtE(self, recordType, b):
         """
         Try to decrypt record assuming it is encrypted with the legacy
@@ -1057,8 +1131,12 @@ class TLSRecordLayer(object):
 
     def _decryptRecord(self, recordType, b):
         if self._readState.encContext:
-            for result in self._decryptRecordWithMtE(recordType, b):
-                yield result
+            if self.etm:
+                for result in self._decryptRecordWithEtM(recordType, b):
+                    yield result
+            else:
+                for result in self._decryptRecordWithMtE(recordType, b):
+                    yield result
         else:
             yield b
 

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -3,6 +3,7 @@
 #   Google (adapted by Sam Rushing) - NPN support
 #   Martin von Loewis - python 3 port
 #   Yngve Pettersen (ported by Paul Sokolovsky) - TLS 1.2
+#   Hubert Kario - Encrypt then MAC - RFC 7366
 #
 # See the LICENSE file for legal information regarding use of this file.
 
@@ -532,6 +533,66 @@ class TLSRecordLayer(object):
                 yield result
             randomizeFirstBlock = True
 
+    def _macThenEncrypt(self, buf, contentType):
+        """
+        Apply encryption and MAC protection on the record layer payload. Use
+        the legacy MAC-then-encrypt construct.
+
+        @type buf: bytes
+        @param buf: payload
+        @type contentType: int
+        @param contentType: record layer content type
+        """
+        #Calculate MAC
+        if self._writeState.macContext:
+            seqnumBytes = self._writeState.getSeqNumBytes()
+            mac = self._writeState.macContext.copy()
+            mac.update(compatHMAC(seqnumBytes))
+            mac.update(compatHMAC(bytearray([contentType])))
+            if self.version == (3, 0):
+                mac.update(compatHMAC(bytearray([len(buf)//256])))
+                mac.update(compatHMAC(bytearray([len(buf)%256])))
+            elif self.version in ((3, 1), (3, 2), (3, 3)):
+                mac.update(compatHMAC(bytearray([self.version[0]])))
+                mac.update(compatHMAC(bytearray([self.version[1]])))
+                mac.update(compatHMAC(bytearray([len(buf)//256])))
+                mac.update(compatHMAC(bytearray([len(buf)%256])))
+            else:
+                raise AssertionError()
+            mac.update(compatHMAC(buf))
+            macBytes = bytearray(mac.digest())
+            if self.fault == Fault.badMAC:
+                macBytes[0] = (macBytes[0]+1) % 256
+
+        #Encrypt for Block or Stream Cipher
+        if self._writeState.encContext:
+            #Add padding and encrypt (for Block Cipher):
+            if self._writeState.encContext.isBlockCipher:
+
+                #Add TLS 1.1 fixed block
+                if self.version >= (3,2):
+                    buf = self.fixedIVBlock + buf
+
+                #Add padding: buf = buf+ (macBytes + paddingBytes)
+                currentLength = len(buf) + len(macBytes) + 1
+                blockLength = self._writeState.encContext.block_size
+                paddingLength = blockLength-(currentLength % blockLength)
+
+                paddingBytes = bytearray([paddingLength] * (paddingLength+1))
+                if self.fault == Fault.badPadding:
+                    paddingBytes[0] = (paddingBytes[0]+1) % 256
+                endBytes = macBytes + paddingBytes
+                buf += endBytes
+                #Encrypt
+                buf = self._writeState.encContext.encrypt(buf)
+
+            #Encrypt (for Stream Cipher)
+            else:
+                buf += macBytes
+                buf = self._writeState.encContext.encrypt(buf)
+
+        return buf
+
     def _sendMsg(self, msg, randomizeFirstBlock = True):
         #Whenever we're connected and asked to send an app data message,
         #we first send the first byte of the message.  This prevents
@@ -544,15 +605,15 @@ class TLSRecordLayer(object):
             msgFirstByte = msg.splitFirstByte()
             for result in self._sendMsg(msgFirstByte,
                                        randomizeFirstBlock = False):
-                yield result                                            
+                yield result
 
         b = msg.write()
-        
-        # If a 1-byte message was passed in, and we "split" the 
+
+        # If a 1-byte message was passed in, and we "split" the
         # first(only) byte off above, we may have a 0-length msg:
         if len(b) == 0:
             return
-            
+
         contentType = msg.contentType
 
         #Update handshake hashes
@@ -561,53 +622,7 @@ class TLSRecordLayer(object):
             self._handshake_sha.update(compat26Str(b))
             self._handshake_sha256.update(compat26Str(b))
 
-        #Calculate MAC
-        if self._writeState.macContext:
-            seqnumBytes = self._writeState.getSeqNumBytes()
-            mac = self._writeState.macContext.copy()
-            mac.update(compatHMAC(seqnumBytes))
-            mac.update(compatHMAC(bytearray([contentType])))
-            if self.version == (3,0):
-                mac.update( compatHMAC( bytearray([len(b)//256] )))
-                mac.update( compatHMAC( bytearray([len(b)%256] )))
-            elif self.version in ((3,1), (3,2), (3,3)):
-                mac.update(compatHMAC( bytearray([self.version[0]] )))
-                mac.update(compatHMAC( bytearray([self.version[1]] )))
-                mac.update( compatHMAC( bytearray([len(b)//256] )))
-                mac.update( compatHMAC( bytearray([len(b)%256] )))
-            else:
-                raise AssertionError()
-            mac.update(compatHMAC(b))
-            macBytes = bytearray(mac.digest())
-            if self.fault == Fault.badMAC:
-                macBytes[0] = (macBytes[0]+1) % 256
-
-        #Encrypt for Block or Stream Cipher
-        if self._writeState.encContext:
-            #Add padding and encrypt (for Block Cipher):
-            if self._writeState.encContext.isBlockCipher:
-
-                #Add TLS 1.1 fixed block
-                if self.version >= (3,2):
-                    b = self.fixedIVBlock + b
-
-                #Add padding: b = b+ (macBytes + paddingBytes)
-                currentLength = len(b) + len(macBytes) + 1
-                blockLength = self._writeState.encContext.block_size
-                paddingLength = blockLength-(currentLength % blockLength)
-
-                paddingBytes = bytearray([paddingLength] * (paddingLength+1))
-                if self.fault == Fault.badPadding:
-                    paddingBytes[0] = (paddingBytes[0]+1) % 256
-                endBytes = macBytes + paddingBytes
-                b += endBytes
-                #Encrypt
-                b = self._writeState.encContext.encrypt(b)
-
-            #Encrypt (for Stream Cipher)
-            else:
-                b += macBytes
-                b = self._writeState.encContext.encrypt(b)
+        b = self._macThenEncrypt(b, contentType)
 
         #Add record header and send
         r = RecordHeader3().create(self.version, contentType, len(b))
@@ -951,88 +966,101 @@ class TLSRecordLayer(object):
             self._handshakeBuffer = self._handshakeBuffer[1:]
             yield (recordHeader, Parser(b))
 
+    def _decryptRecordWithMtE(self, recordType, b):
+        """
+        Try to decrypt record assuming it is encrypted with the legacy
+        MAC-then-encrypt mechanism.
+
+        @type recordType: int
+        @param recordType: numeric type of record contents
+        @type b: bytearray
+        @param b: encypted payload
+        """
+        #Decrypt if it's a block cipher
+        if self._readState.encContext.isBlockCipher:
+            blockLength = self._readState.encContext.block_size
+            if len(b) % blockLength != 0:
+                for result in self._sendError(\
+                        AlertDescription.decryption_failed,
+                        "Encrypted data not a multiple of blocksize"):
+                    yield result
+            b = self._readState.encContext.decrypt(b)
+            if self.version >= (3, 2): #For TLS 1.1, remove explicit IV
+                b = b[self._readState.encContext.block_size : ]
+
+            #Check padding
+            paddingGood = True
+            paddingLength = b[-1]
+            if (paddingLength+1) > len(b):
+                paddingGood = False
+                totalPaddingLength = 0
+            else:
+                if self.version == (3, 0):
+                    totalPaddingLength = paddingLength+1
+                elif self.version in ((3, 1), (3, 2), (3, 3)):
+                    totalPaddingLength = paddingLength+1
+                    paddingBytes = b[-totalPaddingLength:-1]
+                    for byte in paddingBytes:
+                        if byte != paddingLength:
+                            paddingGood = False
+                            totalPaddingLength = 0
+                else:
+                    raise AssertionError()
+
+        #Decrypt if it's a stream cipher
+        else:
+            paddingGood = True
+            b = self._readState.encContext.decrypt(b)
+            totalPaddingLength = 0
+
+        #Check MAC
+        macGood = True
+        macLength = self._readState.macContext.digest_size
+        endLength = macLength + totalPaddingLength
+        if endLength > len(b):
+            macGood = False
+        else:
+            #Read MAC
+            startIndex = len(b) - endLength
+            endIndex = startIndex + macLength
+            checkBytes = b[startIndex : endIndex]
+
+            #Calculate MAC
+            seqnumBytes = self._readState.getSeqNumBytes()
+            b = b[:-endLength]
+            mac = self._readState.macContext.copy()
+            mac.update(compatHMAC(seqnumBytes))
+            mac.update(compatHMAC(bytearray([recordType])))
+            if self.version == (3, 0):
+                mac.update(compatHMAC(bytearray([len(b)//256])))
+                mac.update(compatHMAC(bytearray([len(b)%256])))
+            elif self.version in ((3, 1), (3, 2), (3, 3)):
+                mac.update(compatHMAC(bytearray([self.version[0]])))
+                mac.update(compatHMAC(bytearray([self.version[1]])))
+                mac.update(compatHMAC(bytearray([len(b)//256])))
+                mac.update(compatHMAC(bytearray([len(b)%256])))
+            else:
+                raise AssertionError()
+            mac.update(compatHMAC(b))
+            macBytes = bytearray(mac.digest())
+
+            #Compare MACs
+            if macBytes != checkBytes:
+                macGood = False
+
+        if not (paddingGood and macGood):
+            for result in self._sendError(AlertDescription.bad_record_mac,
+                                          "MAC failure (or padding failure)"):
+                yield result
+
+        yield b
 
     def _decryptRecord(self, recordType, b):
         if self._readState.encContext:
-
-            #Decrypt if it's a block cipher
-            if self._readState.encContext.isBlockCipher:
-                blockLength = self._readState.encContext.block_size
-                if len(b) % blockLength != 0:
-                    for result in self._sendError(\
-                            AlertDescription.decryption_failed,
-                            "Encrypted data not a multiple of blocksize"):
-                        yield result
-                b = self._readState.encContext.decrypt(b)
-                if self.version >= (3,2): #For TLS 1.1, remove explicit IV
-                    b = b[self._readState.encContext.block_size : ]
-
-                #Check padding
-                paddingGood = True
-                paddingLength = b[-1]
-                if (paddingLength+1) > len(b):
-                    paddingGood=False
-                    totalPaddingLength = 0
-                else:
-                    if self.version == (3,0):
-                        totalPaddingLength = paddingLength+1
-                    elif self.version in ((3,1), (3,2), (3,3)):
-                        totalPaddingLength = paddingLength+1
-                        paddingBytes = b[-totalPaddingLength:-1]
-                        for byte in paddingBytes:
-                            if byte != paddingLength:
-                                paddingGood = False
-                                totalPaddingLength = 0
-                    else:
-                        raise AssertionError()
-
-            #Decrypt if it's a stream cipher
-            else:
-                paddingGood = True
-                b = self._readState.encContext.decrypt(b)
-                totalPaddingLength = 0
-
-            #Check MAC
-            macGood = True
-            macLength = self._readState.macContext.digest_size
-            endLength = macLength + totalPaddingLength
-            if endLength > len(b):
-                macGood = False
-            else:
-                #Read MAC
-                startIndex = len(b) - endLength
-                endIndex = startIndex + macLength
-                checkBytes = b[startIndex : endIndex]
-
-                #Calculate MAC
-                seqnumBytes = self._readState.getSeqNumBytes()
-                b = b[:-endLength]
-                mac = self._readState.macContext.copy()
-                mac.update(compatHMAC(seqnumBytes))
-                mac.update(compatHMAC(bytearray([recordType])))
-                if self.version == (3,0):
-                    mac.update( compatHMAC(bytearray( [len(b)//256] ) ))
-                    mac.update( compatHMAC(bytearray( [len(b)%256] ) ))
-                elif self.version in ((3,1), (3,2), (3,3)):
-                    mac.update(compatHMAC(bytearray( [self.version[0]] ) ))
-                    mac.update(compatHMAC(bytearray( [self.version[1]] ) ))
-                    mac.update(compatHMAC(bytearray( [len(b)//256] ) ))
-                    mac.update(compatHMAC(bytearray( [len(b)%256] ) ))
-                else:
-                    raise AssertionError()
-                mac.update(compatHMAC(b))
-                macBytes = bytearray(mac.digest())
-
-                #Compare MACs
-                if macBytes != checkBytes:
-                    macGood = False
-
-            if not (paddingGood and macGood):
-                for result in self._sendError(AlertDescription.bad_record_mac,
-                                          "MAC failure (or padding failure)"):
-                    yield result
-
-        yield b
+            for result in self._decryptRecordWithMtE(recordType, b):
+                yield result
+        else:
+            yield b
 
     def _handshakeStart(self, client):
         if not self.closed:

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -1,0 +1,94 @@
+# Author: Hubert Kario (c) 2014
+# see LICENCE file for legal information regarding use of this file
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+from tlslite.handshakesettings import HandshakeSettings
+
+class TestHandshakeSettings(unittest.TestCase):
+    def test___init__(self):
+        hs = HandshakeSettings()
+
+        self.assertIsNotNone(hs)
+
+    def test_validate(self):
+        hs = HandshakeSettings()
+        newHS = hs.validate()
+
+        self.assertIsNotNone(newHS)
+        self.assertIsNot(hs, newHS)
+
+    def test_minKeySize_too_small(self):
+        hs = HandshakeSettings()
+        hs.minKeySize = 511
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_minKeySize_too_large(self):
+        hs = HandshakeSettings()
+        hs.minKeySize = 16385
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_maxKeySize_too_small(self):
+        hs = HandshakeSettings()
+        hs.maxKeySize = 511
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_maxKeySize_too_large(self):
+        hs = HandshakeSettings()
+        hs.maxKeySize = 16385
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_maxKeySize_smaller_than_minKeySize(self):
+        hs = HandshakeSettings()
+        hs.maxKeySize = 1024
+        hs.minKeySize = 2048
+
+        # XXX not raised
+        #with self.assertRaises(ValueError):
+        hs.validate()
+
+    def test_cipherNames_with_unknown_name(self):
+        hs = HandshakeSettings()
+        hs.cipherNames = ["aes256"]
+
+        newHs = hs.validate()
+
+        self.assertEqual(["aes256"], newHs.cipherNames)
+
+    def test_cipherNames_with_unknown_name(self):
+        hs = HandshakeSettings()
+        hs.cipherNames = ["aes256gcm", "aes256"]
+
+        with self.assertRaises(ValueError):
+            hs.validate()
+
+    def test_useEncryptThenMAC(self):
+        hs = HandshakeSettings()
+
+        self.assertTrue(hs.useEncryptThenMAC)
+
+        newHS = hs.validate()
+
+        self.assertTrue(newHS.useEncryptThenMAC)
+
+    def test_useEncryptThenMAC_setting(self):
+        hs = HandshakeSettings()
+        hs.useEncryptThenMAC = False
+
+        self.assertFalse(hs.useEncryptThenMAC)
+
+        newHS = hs.validate()
+        self.assertFalse(newHS.useEncryptThenMAC)

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -56,9 +56,8 @@ class TestHandshakeSettings(unittest.TestCase):
         hs.maxKeySize = 1024
         hs.minKeySize = 2048
 
-        # XXX not raised
-        #with self.assertRaises(ValueError):
-        hs.validate()
+        with self.assertRaises(ValueError):
+            hs.validate()
 
     def test_cipherNames_with_unknown_name(self):
         hs = HandshakeSettings()


### PR DESCRIPTION
Implements the encrypt then MAC mechanism for CBC based cipher suites in TLS. Add some simple tests for HandshakeSettings.

Missing:
- client side check for EtM advertised in server hello together with stream or AEAD cipher (it's incorrect use and it will fail to interoperate but won't report correct errors - I'd rather test it using mechanism introduced in #47)
- ability to force use of EtM (abort connection when server didn't select EtM but did select CBC cipher suite - that will need to wait for AEAD to be actually useful)

Changes since v2:
- reworked "move MAC-then-encrypt", "etm decryption" and "etm decryption" to fix most pylint complaints
- rebased on master

Changes since v1:
- reworked "etm decryption" and "etm encryption" patches to better show what is happening, unfortunately the "move MAC-then-encrypt to separate methods" is still rather hard to read, but it's not really possible to make it any better
- rebased on master with fixed tests

Obsoletes #52 
