### PR TITLE
fix session cache problem

### DIFF
--- a/tlslite/sessioncache.py
+++ b/tlslite/sessioncache.py
@@ -73,7 +73,7 @@ class SessionCache(object):
         try:
             #Add the new element
             self.entriesDict[bytes(sessionID)] = session
-            self.entriesList[self.lastIndex] = (sessionID, time.time())
+            self.entriesList[self.lastIndex] = (bytes(sessionID), time.time())
             self.lastIndex = (self.lastIndex+1) % len(self.entriesList)
 
             #If the cache is full, we delete the oldest element to make an

--- a/unit_tests/test_tlslite_sessioncache.py
+++ b/unit_tests/test_tlslite_sessioncache.py
@@ -1,0 +1,47 @@
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+import time
+
+from tlslite.sessioncache import SessionCache
+
+class TestGetAttributeAfterPurge(unittest.TestCase):
+    """
+    This tests the following scenario
+
+    Add an entry to the session cache
+    wait until the cache should have expired
+    fetch the entry for the session cache.
+
+    """
+
+    def setUp(self):
+        # set maxAge to 0 to have an immediate expire
+        self.session_cache = SessionCache(maxAge=0)
+
+    def test_fetch_after_expire(self):
+        key = bytearray(b'hello world')
+        self.session_cache[key] = "42"
+        with self.assertRaises(KeyError):
+            self.session_cache[key] 
+
+class TestFillLinkedList(unittest.TestCase):
+    """ check what happens if the linked list gets full
+    """
+
+    def setUp(self):
+        self.session_cache = SessionCache(maxEntries = 10)
+
+    def test_fill_linked_list(self):
+        """this test should not throw an exception"""
+        for i in range(20):
+            key = bytearray(b'prefill-') + bytearray(str(i), "ascii")
+            self.session_cache[key] = "forty-two"
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unit_tests/test_tlslite_sessioncache.py
+++ b/unit_tests/test_tlslite_sessioncache.py
@@ -5,8 +5,6 @@ try:
 except ImportError:
     import unittest
 
-import time
-
 from tlslite.sessioncache import SessionCache
 
 class TestGetAttributeAfterPurge(unittest.TestCase):


### PR DESCRIPTION
The following shows a problem in the session cache and provides a fix. SessionIDs are usually bytearrays and must be converted to bytes when used as an index in a dictionary.

However, the old code stores the byte array in the linked list and use the value from the linked list without conversion to access the dictionary during the purge operation. This will throw an runtime error

TypeError: unhashable type: 'bytearray'
This patch fixes this by converting the bytearry to bytes on inserting it to the linked list

It also adds 2 unit test which will reproduce the problem in 2 different ways.