### PR TITLE
Tests and a fix for ClientHello class

### DIFF
--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -532,13 +532,6 @@ class ClientHello(HandshakeMsg):
             w.bytes += w2.bytes
         return self.postWrite(w)
 
-class BadNextProtos(Exception):
-    def __init__(self, l):
-        self.length = l
-
-    def __str__(self):
-        return 'Cannot encode a list of next protocols because it contains an element with invalid length %d. Element lengths must be 0 < x < 256' % self.length
-
 class ServerHello(HandshakeMsg):
     """server_hello message
 

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -418,7 +418,7 @@ class ClientHello(HandshakeMsg):
             sni_ext = SNIExtension().create(hostname)
             self.addExtension(sni_ext)
         else:
-            names = sni_ext.host_names
+            names = list(sni_ext.host_names)
             names[0] = hostname
             sni_ext.host_names = names
 

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -480,6 +480,30 @@ class TestClientHello(unittest.TestCase):
         ext = client_hello.getExtension(ExtensionType.srp)
         self.assertEqual(ext.identity, b'her-name')
 
+    def test_tack(self):
+        client_hello = ClientHello().create((3, 3), bytearray(1), bytearray(0),
+                [])
+
+        self.assertFalse(client_hello.tack)
+
+        client_hello.tack = True
+
+        self.assertTrue(client_hello.tack)
+
+        client_hello.tack = True
+
+        self.assertTrue(client_hello.tack)
+
+        ext = client_hello.getExtension(ExtensionType.tack)
+        self.assertIsNotNone(ext)
+
+        client_hello.tack = False
+
+        self.assertFalse(client_hello.tack)
+
+        ext = client_hello.getExtension(ExtensionType.tack)
+        self.assertIsNone(ext)
+
 class TestServerHello(unittest.TestCase):
     def test___init__(self):
         server_hello = ServerHello()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -463,6 +463,23 @@ class TestClientHello(unittest.TestCase):
         ext = client_hello.getExtension(ExtensionType.cert_type)
         self.assertEqual(ext.cert_types, [0, 1, 2])
 
+    def test_srp_username(self):
+        client_hello = ClientHello().create((3, 3), bytearray(1), bytearray(0),
+                [])
+
+        self.assertIsNone(client_hello.srp_username)
+
+        client_hello.srp_username = b'my-name'
+
+        self.assertEqual(client_hello.srp_username, b'my-name')
+
+        client_hello.srp_username = b'her-name'
+
+        self.assertEqual(client_hello.srp_username, b'her-name')
+
+        ext = client_hello.getExtension(ExtensionType.srp)
+        self.assertEqual(ext.identity, b'her-name')
+
 class TestServerHello(unittest.TestCase):
     def test___init__(self):
         server_hello = ServerHello()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -504,6 +504,30 @@ class TestClientHello(unittest.TestCase):
         ext = client_hello.getExtension(ExtensionType.tack)
         self.assertIsNone(ext)
 
+    def test_supports_npn(self):
+        client_hello = ClientHello().create((3, 3), bytearray(1), bytearray(0),
+                [])
+
+        self.assertFalse(client_hello.supports_npn)
+
+        client_hello.supports_npn = True
+
+        self.assertTrue(client_hello.supports_npn)
+
+        client_hello.supports_npn = True
+
+        self.assertTrue(client_hello.supports_npn)
+
+        ext = client_hello.getExtension(ExtensionType.supports_npn)
+        self.assertIsNotNone(ext)
+
+        client_hello.supports_npn = False
+
+        self.assertFalse(client_hello.supports_npn)
+
+        ext = client_hello.getExtension(ExtensionType.supports_npn)
+        self.assertIsNone(ext)
+
 class TestServerHello(unittest.TestCase):
     def test___init__(self):
         server_hello = ServerHello()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -528,6 +528,32 @@ class TestClientHello(unittest.TestCase):
         ext = client_hello.getExtension(ExtensionType.supports_npn)
         self.assertIsNone(ext)
 
+    def test_server_name(self):
+        client_hello = ClientHello().create((3, 3), bytearray(1), bytearray(0),
+                [])
+
+        client_hello.server_name = b'example.com'
+
+        self.assertEqual(client_hello.server_name, b'example.com')
+
+        client_hello.server_name = b'example.org'
+
+        self.assertEqual(client_hello.server_name, b'example.org')
+
+        ext = client_hello.getExtension(ExtensionType.server_name)
+        self.assertIsNotNone(ext)
+
+    def test_server_name_other_than_dns_name(self):
+        client_hello = ClientHello().create((3, 3), bytearray(1), bytearray(0),
+                [])
+
+        sni_ext = SNIExtension().create(server_names=[\
+                SNIExtension.ServerName(1, b'test')])
+
+        client_hello.extensions = [sni_ext]
+
+        self.assertEqual(client_hello.server_name, bytearray(0))
+
 class TestServerHello(unittest.TestCase):
     def test___init__(self):
         server_hello = ServerHello()


### PR DESCRIPTION
coverage for srp_username, tack, supports_npn and server_name properties.
Fixes a bug with server_name properties where it was impossible to change once set server_name using the property.