### PR TITLE
Fix compatibility issues with pycrypto and gmpy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 language: python
 
+addons:
+  apt_packages:
+    # needed for M2Crypto
+    - swig
+    # needed for GMPY
+    - libgmp-dev
+
 python:
   - 2.6
   - 2.7
@@ -19,6 +26,21 @@ matrix:
       env: TACKPY=true
     - python: 3.4
       env: TACKPY=true
+    - python: 2.7
+      env: M2CRYPTO=true
+# no M2crypto on Python 3
+    - python: 2.7
+      env: PYCRYPTO=true
+    - python: 3.4
+      env: PYCRYPTO=true
+    - python: 2.7
+      env: GMPY=true
+    - python: 3.4
+      env: GMPY=true
+    - python: 2.7
+      env: M2CRYPTO=true PYCRYPTO=true GMPY=true
+    - python: 3.4
+      env: PYCRYPTO=true GMPY=true
 
 before_install:
   - |
@@ -32,6 +54,9 @@ before_install:
 install:
   - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then travis_retry pip install unittest2; fi
   - if [[ $TACKPY == 'true' ]]; then travis_retry pip install tackpy; fi
+  - if [[ $M2CRYPTO == 'true' ]]; then travis_retry pip install M2Crypto; fi
+  - if [[ $PYCRYPTO == 'true' ]]; then travis_retry pip install pycrypto; fi
+  - if [[ $GMPY == 'true' ]]; then travis_retry pip install gmpy; fi
   - travis_retry pip install -r build-requirements.txt
 
 script:

--- a/tlslite/utils/compat.py
+++ b/tlslite/utils/compat.py
@@ -48,6 +48,9 @@ if sys.version_info >= (3,0):
     def readStdinBinary():
         return sys.stdin.buffer.read()        
 
+    def compatLong(num):
+        return int(num)
+
 else:
     # Python 2.6 requires strings instead of bytearrays in a couple places,
     # so we define this function so it does the conversion if needed.
@@ -79,6 +82,9 @@ else:
         
     def b2a_base64(b):
         return binascii.b2a_base64(compat26Str(b))
+
+    def compatLong(num):
+        return long(num)
         
 import traceback
 def formatExceptionTrace(e):

--- a/tlslite/utils/cryptomath.py
+++ b/tlslite/utils/cryptomath.py
@@ -208,7 +208,7 @@ if gmpyLoaded:
         power = gmpy.mpz(power)
         modulus = gmpy.mpz(modulus)
         result = pow(base, power, modulus)
-        return long(result)
+        return compatLong(result)
 
 else:
     def powMod(base, power, modulus):

--- a/tlslite/utils/pycrypto_rsakey.py
+++ b/tlslite/utils/pycrypto_rsakey.py
@@ -7,6 +7,7 @@ from .cryptomath import *
 
 from .rsakey import *
 from .python_rsakey import Python_RSAKey
+from .compat import compatLong
 
 if pycryptoLoaded:
 
@@ -15,9 +16,11 @@ if pycryptoLoaded:
     class PyCrypto_RSAKey(RSAKey):
         def __init__(self, n=0, e=0, d=0, p=0, q=0, dP=0, dQ=0, qInv=0):
             if not d:
-                self.rsa = RSA.construct( (long(n), long(e)) )
+                self.rsa = RSA.construct((compatLong(n), compatLong(e)))
             else:
-                self.rsa = RSA.construct( (long(n), long(e), long(d), long(p), long(q)) )
+                self.rsa = RSA.construct((compatLong(n), compatLong(e),
+                                          compatLong(d), compatLong(p),
+                                          compatLong(q)))
 
         def __getattr__(self, name):
             return getattr(self.rsa, name)


### PR DESCRIPTION
`tlslite` doesn't work when pycrypto or gmpy is installed on Python3

run tests with dependencies installed

Since tlslite supports different cryptographic backends, tests should
include scenarios with those libraries installed to avoid regressions
to this