### PR TITLE
add output of `coverage html` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ coverage.xml
 pylint_report.txt
 build/
 docs/
+htmlcov/


### PR DESCRIPTION
`coverage html` creates a lot of files in main directory which we will never want to commit so add them to `.gitignore`