### PR TITLE
[v4] Implement RFC 7366 - encrypt then MAC

### DIFF
--- a/scripts/tls.py
+++ b/scripts/tls.py
@@ -182,6 +182,7 @@ def printGoodConnection(connection, seconds):
         print("  TACK: %s" % emptyStr)
         print(str(connection.session.tackExt))
     print("  Next-Protocol Negotiated: %s" % connection.next_proto) 
+    print("  Encrypt-then-MAC: {0}".format(connection.encryptThenMAC))
     
 
 def clientCmd(argv):

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -473,6 +473,55 @@ def clientTestCmd(argv):
     assert not connection.encryptThenMAC
     connection.close()
 
+    print("Test 26.c - resumption with EtM")
+    synchro.recv(1)
+    connection = connect()
+    connection.handshakeClientCert(serverName=address[0])
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.resumed
+    assert connection.encryptThenMAC
+    connection.close()
+    session = connection.session
+
+    # resume
+    synchro.recv(1)
+    connection = connect()
+    connection.handshakeClientCert(serverName=address[0], session=session)
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert connection.resumed
+    assert connection.encryptThenMAC
+    connection.close()
+
+    print("Test 26.d - resumption with no EtM in 2nd handshake")
+    synchro.recv(1)
+    connection = connect()
+    connection.handshakeClientCert(serverName=address[0])
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.resumed
+    assert connection.encryptThenMAC
+    connection.close()
+    session = connection.session
+
+    # resume
+    synchro.recv(1)
+    settings = HandshakeSettings()
+    settings.useEncryptThenMAC = False
+    connection = connect()
+    try:
+        connection.handshakeClientCert(serverName=address[0], session=session,
+                                       settings=settings)
+    except TLSRemoteAlert as e:
+        assert str(e) == "handshake_failure"
+    else:
+        raise AssertionError("No exception raised")
+    connection.close()
+
     print('Test 27 - good standard XMLRPC https client')
     address = address[0], address[1]+1
     synchro.recv(1)
@@ -925,6 +974,44 @@ def serverTestCmd(argv):
     connection = connect()
     connection.handshakeServer(certChain=x509Chain, privateKey=x509Key)
     testConnServer(connection)
+    connection.close()
+
+    print("Test 26.c - resumption with EtM")
+    synchro.send(b'R')
+    sessionCache = SessionCache()
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               sessionCache=sessionCache)
+    testConnServer(connection)
+    connection.close()
+
+    # resume
+    synchro.send(b'R')
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               sessionCache=sessionCache)
+    testConnServer(connection)
+    connection.close()
+
+    print("Test 26.d - resumption with no EtM in 2nd handshake")
+    synchro.send(b'R')
+    sessionCache = SessionCache()
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               sessionCache=sessionCache)
+    testConnServer(connection)
+    connection.close()
+
+    # resume
+    synchro.send(b'R')
+    connection = connect()
+    try:
+        connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                                   sessionCache=sessionCache)
+    except TLSLocalAlert as e:
+        assert str(e) == "handshake_failure"
+    else:
+        raise AssertionError("no exception raised")
     connection.close()
 
     print("Tests 27-29 - XMLRPXC server")

--- a/tests/tlstest.py
+++ b/tests/tlstest.py
@@ -117,6 +117,7 @@ def clientTestCmd(argv):
     testConnClient(connection)
     assert(isinstance(connection.session.serverCertChain, X509CertChain))
     assert(connection.session.serverName == address[0])
+    assert connection.encryptThenMAC == True
     connection.close()
 
     print("Test 1.a - good X509, SSLv3")
@@ -448,7 +449,31 @@ def clientTestCmd(argv):
             raise
     connection.close()
 
-    print('Test 26 - good standard XMLRPC https client')
+    print("Test 26.a - no EtM server side")
+    synchro.recv(1)
+    connection = connect()
+    settings = HandshakeSettings()
+    assert settings.useEncryptThenMAC
+    connection.handshakeClientCert(serverName=address[0], settings=settings)
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.encryptThenMAC
+    connection.close()
+
+    print("Test 26.b - no EtM client side")
+    synchro.recv(1)
+    connection = connect()
+    settings = HandshakeSettings()
+    settings.useEncryptThenMAC = False
+    connection.handshakeClientCert(serverName=address[0], settings=settings)
+    testConnClient(connection)
+    assert isinstance(connection.session.serverCertChain, X509CertChain)
+    assert connection.session.serverName == address[0]
+    assert not connection.encryptThenMAC
+    connection.close()
+
+    print('Test 27 - good standard XMLRPC https client')
     address = address[0], address[1]+1
     synchro.recv(1)
     try:
@@ -465,7 +490,7 @@ def clientTestCmd(argv):
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
-    print('Test 27 - good tlslite XMLRPC client')
+    print('Test 28 - good tlslite XMLRPC client')
     transport = XMLRPCTransport(ignoreAbruptClose=True)
     server = xmlrpclib.Server('https://%s:%s' % address, transport)
     synchro.recv(1)
@@ -473,22 +498,22 @@ def clientTestCmd(argv):
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
-    print('Test 28 - good XMLRPC ignored protocol')
+    print('Test 29 - good XMLRPC ignored protocol')
     server = xmlrpclib.Server('http://%s:%s' % address, transport)
     synchro.recv(1)
     assert server.add(1,2) == 3
     synchro.recv(1)
     assert server.pow(2,4) == 16
 
-    print("Test 29 - Internet servers test")
+    print("Test 30 - Internet servers test")
     try:
         i = IMAP4_TLS("cyrus.andrew.cmu.edu")
         i.login("anonymous", "anonymous@anonymous.net")
         i.logout()
-        print("Test 30: IMAP4 good")
+        print("Test 31: IMAP4 good")
         p = POP3_TLS("pop.gmail.com")
         p.quit()
-        print("Test 31: POP3 good")
+        print("Test 32: POP3 good")
     except socket.error as e:
         print("Non-critical error: socket error trying to reach internet server: ", e)   
 
@@ -885,7 +910,24 @@ def serverTestCmd(argv):
             raise
     connection.close()
 
-    print("Tests 26-28 - XMLRPXC server")
+    print("Test 26.a - no EtM server side")
+    synchro.send(b'R')
+    connection = connect()
+    settings = HandshakeSettings()
+    settings.useEncryptThenMAC = False
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key,
+                               settings=settings)
+    testConnServer(connection)
+    connection.close()
+
+    print("Test 26.b - no EtM client side")
+    synchro.send(b'R')
+    connection = connect()
+    connection.handshakeServer(certChain=x509Chain, privateKey=x509Key)
+    testConnServer(connection)
+    connection.close()
+
+    print("Tests 27-29 - XMLRPXC server")
     address = address[0], address[1]+1
     class Server(TLSXMLRPCServer):
 

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -44,6 +44,7 @@ class ExtensionType:    # RFC 6066 / 4366
     server_name = 0     # RFC 6066 / 4366
     srp = 12            # RFC 5054  
     cert_type = 9       # RFC 6091
+    encrypt_then_mac = 22 # RFC 7366
     tack = 0xF300
     supports_npn = 13172
     

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -198,3 +198,11 @@ class TLSIllegalParameterException(TLSProtocolException):
 class TLSRecordOverflow(TLSProtocolException):
     """The received record size was too big"""
     pass
+
+class TLSDecryptionFailed(TLSProtocolException):
+    """Decryption of data was unsuccessful"""
+    pass
+
+class TLSBadRecordMAC(TLSProtocolException):
+    """Bad MAC (or padding in case of mac-then-encrypt)"""
+    pass

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -14,7 +14,15 @@ import socket
 
 from .constants import AlertDescription, AlertLevel
 
-class TLSError(Exception):
+class BaseTLSException(Exception):
+    """Metaclass for TLS Lite exceptions.
+
+    Look to L{TLSError} for exceptions that should be caught by tlslite
+    consumers
+    """
+    pass
+
+class TLSError(BaseTLSException):
     """Base class for all TLS Lite exceptions."""
     
     def __str__(self):
@@ -173,5 +181,20 @@ class TLSUnsupportedError(TLSError):
     pass
 
 class TLSInternalError(TLSError):
-    """The internal state of object is unexpected or invalid"""
+    """The internal state of object is unexpected or invalid.
+
+    Caused by incorrect use of API.
+    """
+    pass
+
+class TLSProtocolException(BaseTLSException):
+    """Exceptions used internally for handling errors in received messages"""
+    pass
+
+class TLSIllegalParameterException(TLSProtocolException):
+    """Parameters specified in message were incorrect or invalid"""
+    pass
+
+class TLSRecordOverflow(TLSProtocolException):
+    """The received record size was too big"""
     pass

--- a/tlslite/handshakesettings.py
+++ b/tlslite/handshakesettings.py
@@ -110,6 +110,7 @@ class HandshakeSettings(object):
         self.maxVersion = (3,3)
         self.useExperimentalTackExtension = False
         self.sendFallbackSCSV = False
+        self.useEncryptThenMAC = True
 
     def validate(self):
         """
@@ -130,6 +131,7 @@ class HandshakeSettings(object):
         other.minVersion = self.minVersion
         other.maxVersion = self.maxVersion
         other.sendFallbackSCSV = self.sendFallbackSCSV
+        other.useEncryptThenMAC = self.useEncryptThenMAC
 
         if not cipherfactory.tripleDESPresent:
             other.cipherNames = [e for e in self.cipherNames if e != "3des"]
@@ -179,6 +181,9 @@ class HandshakeSettings(object):
         if other.maxVersion < (3,3):
             # No sha256 pre TLS 1.2
             other.macNames = [e for e in self.macNames if e != "sha256"]
+
+        if other.useEncryptThenMAC not in (True, False):
+            raise ValueError("useEncryptThenMAC can only be True or False")
 
         return other
 

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -82,6 +82,25 @@ class RecordHeader2(object):
         self.length = p.get(1)
         return self
 
+class Message(object):
+
+    """Generic TLS message"""
+
+    def __init__(self, contentType, data):
+        """
+        Initialize object with specified contentType and data
+
+        @type contentType: int
+        @param contentType: TLS record layer content type of associated data
+        @type data: bytearray
+        @param data: data
+        """
+        self.contentType = contentType
+        self.data = data
+
+    def write(self):
+        """Return serialised object data"""
+        return self.data
 
 class Alert(object):
     def __init__(self):

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -6,11 +6,16 @@
 
 import socket
 import errno
-from tlslite.constants import ContentType
-from .messages import RecordHeader3, RecordHeader2
-from .utils.codec import Parser
+import hashlib
+from .constants import ContentType, CipherSuite
+from .messages import RecordHeader3, RecordHeader2, Message
+from .utils.cipherfactory import createAES, createRC4, createTripleDES
+from .utils.codec import Parser, Writer
+from .utils.compat import compatHMAC
+from .utils.cryptomath import getRandomBytes
 from .errors import TLSRecordOverflow, TLSIllegalParameterException,\
         TLSAbruptCloseError
+from .mathtls import createMAC_SSL, createHMAC, PRF_SSL, PRF, PRF_1_2
 
 class RecordSocket(object):
 
@@ -181,3 +186,238 @@ class RecordSocket(object):
 
         yield (record, buf)
 
+class ConnectionState(object):
+
+    """Preserve the connection state for reading and writing data to records"""
+
+    def __init__(self):
+        """Create an instance with empty encryption and MACing contexts"""
+        self.macContext = None
+        self.encContext = None
+        self.seqnum = 0
+
+    def getSeqNumBytes(self):
+        """Return encoded sequence number and increment it."""
+        writer = Writer()
+        writer.add(self.seqnum, 8)
+        self.seqnum += 1
+        return writer.bytes
+
+class RecordLayer(object):
+
+    """
+    Implementation of TLS record layer protocol
+
+    @ivar version: the TLS version to use (tuple encoded as on the wire)
+    @ivar sock: underlying socket
+    @ivar client: whatever the connection should use encryption
+    """
+
+    def __init__(self, sock):
+        self.sock = sock
+        self._recordSocket = RecordSocket(sock)
+        self._version = (0, 0)
+
+        self.client = True
+
+        self._writeState = ConnectionState()
+        self._readState = ConnectionState()
+        self._pendingWriteState = ConnectionState()
+        self._pendingReadState = ConnectionState()
+        self.fixedIVBlock = None
+
+    @property
+    def version(self):
+        """Return the TLS version used by record layer"""
+        return self._version
+
+    @version.setter
+    def version(self, val):
+        """Set the TLS version used by record layer"""
+        self._version = val
+        self._recordSocket.version = val
+
+    #
+    # sending messages
+    #
+
+    def _macThenEncrypt(self, b, contentType):
+        """MAC then encrypt data"""
+        if self._writeState.macContext:
+            seqnumBytes = self._writeState.getSeqNumBytes()
+            mac = self._writeState.macContext.copy()
+            mac.update(compatHMAC(seqnumBytes))
+            mac.update(compatHMAC(bytearray([contentType])))
+            assert self.version in ((3, 0), (3, 1), (3, 2), (3, 3))
+            if self.version == (3, 0):
+                mac.update(compatHMAC(bytearray([len(b)//256])))
+                mac.update(compatHMAC(bytearray([len(b)%256])))
+            else:
+                mac.update(compatHMAC(bytearray([self.version[0]])))
+                mac.update(compatHMAC(bytearray([self.version[1]])))
+                mac.update(compatHMAC(bytearray([len(b)//256])))
+                mac.update(compatHMAC(bytearray([len(b)%256])))
+            mac.update(compatHMAC(b))
+            macBytes = bytearray(mac.digest())
+
+        #Encrypt for Block or Stream Cipher
+        if self._writeState.encContext:
+            #Add padding and encrypt (for Block Cipher):
+            if self._writeState.encContext.isBlockCipher:
+
+                #Add TLS 1.1 fixed block
+                if self.version >= (3, 2):
+                    b = self.fixedIVBlock + b
+
+                #Add padding: b = b+ (macBytes + paddingBytes)
+                currentLength = len(b) + len(macBytes)
+                blockLength = self._writeState.encContext.block_size
+                paddingLength = blockLength - 1 - (currentLength % blockLength)
+
+                paddingBytes = bytearray([paddingLength] * (paddingLength+1))
+                endBytes = macBytes + paddingBytes
+                b += endBytes
+                #Encrypt
+                b = self._writeState.encContext.encrypt(b)
+
+            #Encrypt (for Stream Cipher)
+            else:
+                b += macBytes
+                b = self._writeState.encContext.encrypt(b)
+
+        return b
+
+    def sendMessage(self, msg, randomizeFirstBlock=True):
+        """
+        Encrypt, MAC and send message through socket.
+
+        @param msg: TLS message to send
+        @type msg: ApplicationData, HandshakeMessage, etc.
+        @param randomizeFirstBlock: set to perform 1/n-1 record splitting in
+        SSLv3 and TLSv1.0 in application data
+        """
+
+        data = msg.write()
+        contentType = msg.contentType
+
+        data = self._macThenEncrypt(data, contentType)
+
+        encryptedMessage = Message(contentType, data)
+
+        for result in self._recordSocket.send(encryptedMessage):
+            yield result
+
+    #
+    # cryptography state methods
+    #
+
+    def changeWriteState(self):
+        """
+        Change the cipher state to the pending one for write operations.
+
+        This should be done only once after a call to L{calcPendingStates} was
+        performed and directly after sending a L{ChangeCipherSpec} message.
+        """
+        self._writeState = self._pendingWriteState
+        self._pendingWriteState = ConnectionState()
+
+    def changeReadState(self):
+        """
+        Change the cipher state to the pending one for read operations.
+
+        This should be done only once after a call to L{calcPendingStates} was
+        performed and directly after receiving a L{ChangeCipherSpec} message.
+        """
+        self._readState = self._pendingReadState
+        self._pendingReadState = ConnectionState()
+
+    def calcPendingStates(self, cipherSuite, masterSecret, clientRandom,
+                          serverRandom, implementations):
+        """Create pending states for encryption and decryption."""
+        if cipherSuite in CipherSuite.aes128Suites:
+            keyLength = 16
+            ivLength = 16
+            createCipherFunc = createAES
+        elif cipherSuite in CipherSuite.aes256Suites:
+            keyLength = 32
+            ivLength = 16
+            createCipherFunc = createAES
+        elif cipherSuite in CipherSuite.rc4Suites:
+            keyLength = 16
+            ivLength = 0
+            createCipherFunc = createRC4
+        elif cipherSuite in CipherSuite.tripleDESSuites:
+            keyLength = 24
+            ivLength = 8
+            createCipherFunc = createTripleDES
+        else:
+            raise AssertionError()
+
+        if cipherSuite in CipherSuite.shaSuites:
+            macLength = 20
+            digestmod = hashlib.sha1
+        elif cipherSuite in CipherSuite.sha256Suites:
+            macLength = 32
+            digestmod = hashlib.sha256
+        elif cipherSuite in CipherSuite.md5Suites:
+            macLength = 16
+            digestmod = hashlib.md5
+
+        if self.version == (3, 0):
+            createMACFunc = createMAC_SSL
+        elif self.version in ((3, 1), (3, 2), (3, 3)):
+            createMACFunc = createHMAC
+
+        outputLength = (macLength*2) + (keyLength*2) + (ivLength*2)
+
+        #Calculate Keying Material from Master Secret
+        if self.version == (3, 0):
+            keyBlock = PRF_SSL(masterSecret,
+                               serverRandom + clientRandom,
+                               outputLength)
+        elif self.version in ((3, 1), (3, 2)):
+            keyBlock = PRF(masterSecret,
+                           b"key expansion",
+                           serverRandom + clientRandom,
+                           outputLength)
+        elif self.version == (3, 3):
+            keyBlock = PRF_1_2(masterSecret,
+                               b"key expansion",
+                               serverRandom + clientRandom,
+                               outputLength)
+        else:
+            raise AssertionError()
+
+        #Slice up Keying Material
+        clientPendingState = ConnectionState()
+        serverPendingState = ConnectionState()
+        p = Parser(keyBlock)
+        clientMACBlock = p.getFixBytes(macLength)
+        serverMACBlock = p.getFixBytes(macLength)
+        clientKeyBlock = p.getFixBytes(keyLength)
+        serverKeyBlock = p.getFixBytes(keyLength)
+        clientIVBlock = p.getFixBytes(ivLength)
+        serverIVBlock = p.getFixBytes(ivLength)
+        clientPendingState.macContext = createMACFunc(
+            compatHMAC(clientMACBlock), digestmod=digestmod)
+        serverPendingState.macContext = createMACFunc(
+            compatHMAC(serverMACBlock), digestmod=digestmod)
+        clientPendingState.encContext = createCipherFunc(clientKeyBlock,
+                                                         clientIVBlock,
+                                                         implementations)
+        serverPendingState.encContext = createCipherFunc(serverKeyBlock,
+                                                         serverIVBlock,
+                                                         implementations)
+
+        #Assign new connection states to pending states
+        if self.client:
+            self._pendingWriteState = clientPendingState
+            self._pendingReadState = serverPendingState
+        else:
+            self._pendingWriteState = serverPendingState
+            self._pendingReadState = clientPendingState
+
+        if self.version >= (3, 2) and ivLength:
+            #Choose fixedIVBlock for TLS 1.1 (this is encrypted with the CBC
+            #residue to create the IV for each sent block)
+            self.fixedIVBlock = getRandomBytes(ivLength)

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -290,14 +290,11 @@ class RecordLayer(object):
             mac.update(compatHMAC(seqnumBytes))
             mac.update(compatHMAC(bytearray([contentType])))
             assert self.version in ((3, 0), (3, 1), (3, 2), (3, 3))
-            if self.version == (3, 0):
-                mac.update(compatHMAC(bytearray([len(b)//256])))
-                mac.update(compatHMAC(bytearray([len(b)%256])))
-            else:
+            if self.version != (3, 0):
                 mac.update(compatHMAC(bytearray([self.version[0]])))
                 mac.update(compatHMAC(bytearray([self.version[1]])))
-                mac.update(compatHMAC(bytearray([len(b)//256])))
-                mac.update(compatHMAC(bytearray([len(b)%256])))
+            mac.update(compatHMAC(bytearray([len(b)//256])))
+            mac.update(compatHMAC(bytearray([len(b)%256])))
             mac.update(compatHMAC(b))
             macBytes = bytearray(mac.digest())
 

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -237,6 +237,37 @@ class RecordLayer(object):
         self._version = val
         self._recordSocket.version = val
 
+    def getCipherName(self):
+        """
+        Return the name of the bulk cipher used by this connection
+
+        @rtype: str
+        @return: The name of the cipher, like 'aes128', 'rc4', etc.
+        """
+        if self._writeState.encContext is None:
+            return None
+        return self._writeState.encContext.name
+
+    def getCipherImplementation(self):
+        """
+        Return the name of the implementation used for the connection
+
+        'python' for tlslite internal implementation, 'openssl' for M2crypto
+        and 'pycrypto' for pycrypto
+        @rtype: str
+        @return: Name of cipher implementation used, None if not initialised
+        """
+        if self._writeState.encContext is None:
+            return None
+        return self._writeState.encContext.implementation
+
+    def shutdown(self):
+        """Clear read and write states"""
+        self._writeState = ConnectionState()
+        self._readState = ConnectionState()
+        self._pendingWriteState = ConnectionState()
+        self._pendingReadState = ConnectionState()
+
     #
     # sending messages
     #

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -446,6 +446,68 @@ class RecordLayer(object):
 
         return b
 
+    def _macThenDecrypt(self, recordType, buf):
+        """
+        Check MAC of data, then decrypt and remove padding
+
+        @raise TLSBadRecordMAC: when the mac value is invalid
+        @raise TLSDecryptionFailed: when the data to decrypt has invalid size
+        """
+        if self._readState.macContext:
+            macLength = self._readState.macContext.digest_size
+            if len(buf) < macLength:
+                raise TLSBadRecordMAC("Truncated data")
+
+            checkBytes = buf[-macLength:]
+            buf = buf[:-macLength]
+
+            seqnumBytes = self._readState.getSeqNumBytes()
+            mac = self._readState.macContext.copy()
+            mac.update(compatHMAC(seqnumBytes))
+            mac.update(compatHMAC(bytearray([recordType])))
+            mac.update(compatHMAC(bytearray([self.version[0]])))
+            mac.update(compatHMAC(bytearray([self.version[1]])))
+            mac.update(compatHMAC(bytearray([len(buf)//256])))
+            mac.update(compatHMAC(bytearray([len(buf)%256])))
+            mac.update(compatHMAC(buf))
+
+            macBytes = bytearray(mac.digest())
+            if macBytes != checkBytes:
+                raise TLSBadRecordMAC("MAC mismatch")
+
+        if self._readState.encContext:
+            blockLength = self._readState.encContext.block_size
+            if len(buf) % blockLength != 0:
+                raise TLSDecryptionFailed("data length not multiple of "\
+                                          "block size")
+
+            buf = self._readState.encContext.decrypt(buf)
+
+            # remove explicit IV
+            if self.version >= (3, 2):
+                buf = buf[blockLength:]
+
+            # check padding
+            paddingLength = buf[-1]
+            if paddingLength + 1 > len(buf):
+                raise TLSBadRecordMAC("Invalid padding length")
+
+            paddingGood = True
+            totalPaddingLength = paddingLength+1
+            if self.version != (3, 0):
+                paddingBytes = buf[-totalPaddingLength:-1]
+                for byte in paddingBytes:
+                    if byte != paddingLength:
+                        paddingGood = False
+
+            if not paddingGood:
+                raise TLSBadRecordMAC("Invalid padding byte values")
+
+            # remove padding
+            buf = buf[:-totalPaddingLength]
+
+        return buf
+
     def recvMessage(self):
         """
         Read, decrypt and check integrity of message
@@ -464,7 +526,10 @@ class RecordLayer(object):
 
         (header, data) = result
 
-        data = self._decryptThenMAC(header.type, data)
+        if self.encryptThenMAC:
+            data = self._macThenDecrypt(header.type, data)
+        else:
+            data = self._decryptThenMAC(header.type, data)
 
         yield (header, Parser(data))
 

--- a/tlslite/recordlayer.py
+++ b/tlslite/recordlayer.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2014, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+"""Implementation of the TLS Record Layer protocol"""
+
+import socket
+import errno
+from tlslite.constants import ContentType
+from .messages import RecordHeader3, RecordHeader2
+from .utils.codec import Parser
+from .errors import TLSRecordOverflow, TLSIllegalParameterException,\
+        TLSAbruptCloseError
+
+class RecordSocket(object):
+
+    """Socket wrapper for reading and writing TLS Records"""
+
+    def __init__(self, sock):
+        """
+        Assign socket to wrapper
+
+        @type sock: socket.socket
+        """
+        self.sock = sock
+        self.version = (0, 0)
+
+    def _sockSendAll(self, data):
+        """
+        Send all data through socket
+
+        @type data: bytearray
+        @param data: data to send
+        @raise socket.error: when write to socket failed
+        """
+        while 1:
+            try:
+                bytesSent = self.sock.send(data)
+            except socket.error as why:
+                if why.args[0] in (errno.EWOULDBLOCK, errno.EAGAIN):
+                    yield 1
+                    continue
+                raise
+
+            if bytesSent == len(data):
+                return
+            data = data[bytesSent:]
+            yield 1
+
+    def send(self, msg):
+        """
+        Send the message through socket.
+
+        @type msg: bytearray
+        @param msg: TLS message to send
+        @raise socket.error: when write to socket failed
+        """
+
+        data = msg.write()
+
+        header = RecordHeader3().create(self.version,
+                                        msg.contentType,
+                                        len(data))
+
+        data = header.write() + data
+
+        for result in self._sockSendAll(data):
+            yield result
+
+    def _sockRecvAll(self, length):
+        """
+        Read exactly the amount of bytes specified in L{length} from raw socket.
+
+        @rtype: generator
+        @return: generator that will return 0 or 1 in case the socket is non
+           blocking and would block and bytearray in case the read finished
+        @raise TLSAbruptCloseError: when the socket closed
+        """
+
+        buf = bytearray(0)
+
+        if length == 0:
+            yield buf
+
+        while True:
+            try:
+                socketBytes = self.sock.recv(length - len(buf))
+            except socket.error as why:
+                if why.args[0] in (errno.EWOULDBLOCK, errno.EAGAIN):
+                    yield 0
+                    continue
+                else:
+                    raise
+
+            #if the connection closed, raise socket error
+            if len(socketBytes) == 0:
+                raise TLSAbruptCloseError()
+
+            buf += bytearray(socketBytes)
+            if len(buf) == length:
+                yield buf
+
+    def _recvHeader(self):
+        """Read a single record header from socket"""
+        #Read the next record header
+        buf = bytearray(0)
+        ssl2 = False
+        for result in self._sockRecvAll(1):
+            if result in (0, 1):
+                yield result
+            else: break
+        buf += result
+
+        if buf[0] in ContentType.all:
+            ssl2 = False
+            # SSLv3 record layer header is 5 bytes long, we already read 1
+            for result in self._sockRecvAll(4):
+                if result in (0, 1):
+                    yield result
+                else: break
+            buf += result
+        # XXX this should be 'buf[0] & 128', otherwise hello messages longer
+        # than 127 bytes won't be properly parsed
+        elif buf[0] == 128:
+            ssl2 = True
+            # in SSLv2 we need to read 2 bytes in total to know the size of
+            # header, we already read 1
+            for result in self._sockRecvAll(1):
+                if result in (0, 1):
+                    yield result
+                else: break
+            buf += result
+        else:
+            raise TLSIllegalParameterException(
+                "Record header type doesn't specify known type")
+
+        #Parse the record header
+        if ssl2:
+            record = RecordHeader2().parse(Parser(buf))
+        else:
+            record = RecordHeader3().parse(Parser(buf))
+
+        yield record
+
+    def recv(self):
+        """
+        Read a single record from socket, handles both SSLv2 and SSLv3 record
+        layer
+
+        @rtype: generator
+        @return: generator that returns 0 or 1 in case the read would be
+            blocking or a tuple containing record header (object) and record
+            data (bytearray) read from socket
+        @raise socket.error: In case of network error
+        @raise TLSAbruptCloseError: When the socket was closed on the other
+        side in middle of record receiving
+        @raise TLSRecordOverflow: When the received record was longer than
+        allowed by TLS
+        @raise TLSIllegalParameterException: When the record header was
+        malformed
+        """
+
+        for record in self._recvHeader():
+            if record in (0, 1):
+                yield record
+            else: break
+
+        #Check the record header fields
+        # 18432 = 2**14 (basic record size limit) + 1024 (maximum compression
+        # overhead) + 1024 (maximum encryption overhead)
+        if record.length > 18432:
+            raise TLSRecordOverflow()
+
+        #Read the record contents
+        buf = bytearray(0)
+        for result in self._sockRecvAll(record.length):
+            if result in (0, 1):
+                yield result
+            else: break
+        buf += result
+
+        yield (record, buf)
+

--- a/tlslite/session.py
+++ b/tlslite/session.py
@@ -41,7 +41,11 @@ class Session(object):
     @ivar tackExt: The server's TackExtension (or None).
 
     @type tackInHelloExt: L{bool}
-    @ivar tackInHelloExt: True if a TACK was presented via TLS Extension.
+    @ivar tackInHelloExt:True if a TACK was presented via TLS Extension.
+
+    @type encryptThenMAC: bool
+    @ivar encryptThenMAC: True if connection uses CBC cipher in
+    encrypt-then-MAC mode
     """
 
     def __init__(self):
@@ -55,10 +59,12 @@ class Session(object):
         self.tackInHelloExt = False
         self.serverName = ""
         self.resumable = False
+        self.encryptThenMAC = False
 
     def create(self, masterSecret, sessionID, cipherSuite,
             srpUsername, clientCertChain, serverCertChain, 
-            tackExt, tackInHelloExt, serverName, resumable=True):
+            tackExt, tackInHelloExt, serverName, resumable=True,
+            encryptThenMAC=False):
         self.masterSecret = masterSecret
         self.sessionID = sessionID
         self.cipherSuite = cipherSuite
@@ -69,6 +75,7 @@ class Session(object):
         self.tackInHelloExt = tackInHelloExt  
         self.serverName = serverName
         self.resumable = resumable
+        self.encryptThenMAC = encryptThenMAC
 
     def _clone(self):
         other = Session()
@@ -82,6 +89,7 @@ class Session(object):
         other.tackInHelloExt = self.tackInHelloExt
         other.serverName = self.serverName
         other.resumable = self.resumable
+        other.encryptThenMAC = self.encryptThenMAC
         return other
 
     def valid(self):

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -557,9 +557,6 @@ class TLSConnection(TLSRecordLayer):
         #error alerts will use the server's version
         self.version = serverHello.server_version
 
-        #Future responses from server must use this version
-        self._versionCheck = True
-
         #Check ServerHello
         if serverHello.server_version < settings.minVersion:
             for result in self._sendError(\
@@ -1315,9 +1312,6 @@ class TLSConnection(TLSRecordLayer):
                 for result in self._sendMsg(serverHello):
                     yield result
 
-                #From here on, the client's messages must have right version
-                self._versionCheck = True
-
                 #Calculate pending connection states
                 self._calcPendingStates(session.cipherSuite, 
                                         session.masterSecret,
@@ -1412,9 +1406,6 @@ class TLSConnection(TLSRecordLayer):
         for result in self._sendMsgs(msgs):
             yield result
 
-        #From here on, the client's messages must have the right version
-        self._versionCheck = True
-
         #Get and check ClientKeyExchange
         for result in self._getMsg(ContentType.handshake,
                                   HandshakeType.client_key_exchange,
@@ -1460,9 +1451,6 @@ class TLSConnection(TLSRecordLayer):
         msgs.append(ServerHelloDone())
         for result in self._sendMsgs(msgs):
             yield result
-
-        #From here on, the client's messages must have the right version
-        self._versionCheck = True
 
         #Get [Certificate,] (if was requested)
         if reqCert:
@@ -1583,9 +1571,6 @@ class TLSConnection(TLSRecordLayer):
         msgs.append(ServerHelloDone())
         for result in self._sendMsgs(msgs):
             yield result
-        
-        #From here on, the client's messages must have the right version
-        self._versionCheck = True
         
         #Get and check ClientKeyExchange
         for result in self._getMsg(ContentType.handshake,

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -424,6 +424,10 @@ class TLSConnection(TLSRecordLayer):
         # (string or None)
         nextProto = self._clientSelectNextProto(nextProtos, serverHello)
 
+        # Check if server selected encrypt-then-MAC
+        if serverHello.getExtension(ExtensionType.encrypt_then_mac):
+            self._recordLayer.encryptThenMAC = True
+
         #If the server elected to resume the session, it is handled here.
         for result in self._clientResume(session, serverHello, 
                         clientHello.random, 
@@ -515,6 +519,13 @@ class TLSConnection(TLSRecordLayer):
 
         #Initialize acceptable certificate types
         certificateTypes = settings.getCertificateTypes()
+
+        #Initialize TLS extensions
+        if settings.useEncryptThenMAC:
+            extensions = [TLSExtension().create(ExtensionType.encrypt_then_mac,
+                                                bytearray(0))]
+        else:
+            extensions = None
             
         #Either send ClientHello (with a resumable session)...
         if session and session.sessionID:
@@ -530,7 +541,8 @@ class TLSConnection(TLSRecordLayer):
                                    certificateTypes, 
                                    session.srpUsername,
                                    reqTack, nextProtos is not None,
-                                   session.serverName)
+                                   session.serverName,
+                                   extensions=extensions)
 
         #Or send ClientHello (without)
         else:
@@ -540,7 +552,8 @@ class TLSConnection(TLSRecordLayer):
                                certificateTypes, 
                                srpUsername,
                                reqTack, nextProtos is not None, 
-                               serverName)
+                               serverName,
+                               extensions=extensions)
         for result in self._sendMsg(clientHello):
             yield result
         yield clientHello
@@ -1149,10 +1162,21 @@ class TLSConnection(TLSRecordLayer):
             tackExt = TackExtension.create(tacks, activationFlags)
         else:
             tackExt = None
+
+        # Prepare other extensions if requested
+        if settings.useEncryptThenMAC and \
+                clientHello.getExtension(ExtensionType.encrypt_then_mac) and \
+                cipherSuite not in CipherSuite.rc4Suites:
+            extensions = [TLSExtension().create(ExtensionType.encrypt_then_mac,
+                                                bytearray(0))]
+            self._recordLayer.encryptThenMAC = True
+        else:
+            extensions = None
+
         serverHello = ServerHello()
         serverHello.create(self.version, getRandomBytes(32), sessionID, \
-                            cipherSuite, CertificateType.x509, tackExt,
-                            nextProtos)
+                           cipherSuite, CertificateType.x509, tackExt,
+                           nextProtos, extensions=extensions)
 
         # Perform the SRP key exchange
         clientCertChain = None

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -118,9 +118,6 @@ class TLSRecordLayer(object):
         self._handshake_sha = hashlib.sha1()
         self._handshake_sha256 = hashlib.sha256()
 
-        #TLS Protocol Version
-        self._versionCheck = False #Once we choose a version, this is True
-
         #Is the connection open?
         self.closed = True #read-only
         self._refCount = 0 #Used to trigger closure
@@ -523,7 +520,6 @@ class TLSRecordLayer(object):
         self._recordLayer._writeState = _ConnectionState()
         self._recordLayer._readState = _ConnectionState()
         self.version = (0,0)
-        self._versionCheck = False
         self.closed = True
         if self.closeSocket:
             self.sock.close()
@@ -808,20 +804,6 @@ class TLSRecordLayer(object):
                 yield result
         (r, p) = result
         b = p.bytes
-
-        #Check the record header fields (2)
-        #We do this after reading the contents from the socket, so that
-        #if there's an error, we at least don't leave extra bytes in the
-        #socket..
-        #
-        # THIS CHECK HAS NO SECURITY RELEVANCE (?), BUT COULD HURT INTEROP.
-        # SO WE LEAVE IT OUT FOR NOW.
-        #
-        #if self._versionCheck and r.version != self.version:
-        #    for result in self._sendError(AlertDescription.protocol_version,
-        #            "Version in header field: %s, should be %s" % (str(r.version),
-        #                                                       str(self.version))):
-        #        yield result
 
         #Decrypt the record
 

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -405,10 +405,7 @@ class TLSRecordLayer(object):
         @return: The name of the cipher used with this connection.
         Either 'aes128', 'aes256', 'rc4', or '3des'.
         """
-        # TODO don't use private variable of class
-        if not self._recordLayer._writeState.encContext:
-            return None
-        return self._recordLayer._writeState.encContext.name
+        return self._recordLayer.getCipherName()
 
     def getCipherImplementation(self):
         """Get the name of the cipher implementation used with
@@ -418,11 +415,7 @@ class TLSRecordLayer(object):
         @return: The name of the cipher implementation used with
         this connection.  Either 'python', 'openssl', or 'pycrypto'.
         """
-        if not self._recordLayer._writeState.encContext:
-            return None
-        return self._recordLayer._writeState.encContext.implementation
-
-
+        return self._recordLayer.getCipherImplementation()
 
     #Emulate a socket, somewhat -
     def send(self, s):
@@ -516,9 +509,7 @@ class TLSRecordLayer(object):
      #*********************************************************
 
     def _shutdown(self, resumable):
-        # TODO don't use private field
-        self._recordLayer._writeState = _ConnectionState()
-        self._recordLayer._readState = _ConnectionState()
+        self._recordLayer.shutdown()
         self.version = (0,0)
         self.closed = True
         if self.closeSocket:

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -25,19 +25,6 @@ import socket
 import errno
 import traceback
 
-class _ConnectionState(object):
-    def __init__(self):
-        self.macContext = None
-        self.encContext = None
-        self.seqnum = 0
-
-    def getSeqNumBytes(self):
-        w = Writer()
-        w.add(self.seqnum, 8)
-        self.seqnum += 1
-        return w.bytes
-
-
 class TLSRecordLayer(object):
     """
     This class handles data transmission for a TLS connection.

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -19,6 +19,7 @@ from .messages import *
 from .mathtls import *
 from .constants import *
 from .utils.cryptomath import getRandomBytes
+from .recordlayer import RecordSocket
 
 import socket
 import errno
@@ -102,6 +103,7 @@ class TLSRecordLayer(object):
 
     def __init__(self, sock):
         self.sock = sock
+        self._recordSocket = RecordSocket(sock)
 
         #My session object (Session instance; read-only)
         self.session = None
@@ -120,7 +122,7 @@ class TLSRecordLayer(object):
         self._handshake_sha256 = hashlib.sha256()
 
         #TLS Protocol Version
-        self.version = (0,0) #read-only
+        self._version = (0, 0) #read-only
         self._versionCheck = False #Once we choose a version, this is True
 
         #Current and Pending connection states
@@ -148,6 +150,17 @@ class TLSRecordLayer(object):
 
         #Fault we will induce, for testing purposes
         self.fault = None
+
+    @property
+    def version(self):
+        """Get the SSL protocol version of connection"""
+        return self._version
+
+    @version.setter
+    def version(self, value):
+        """Set the SSL protocol version of connection"""
+        self._version = value
+        self._recordSocket.version = value
 
     def clearReadBuffer(self):
         self._readBuffer = b''

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -84,6 +84,11 @@ class TLSRecordLayer(object):
     attacker truncating the connection, and only if necessary to avoid
     spurious errors.  The default is False.
 
+    @type encryptThenMAC: bool
+    @ivear encryptThenMAC: Whether the connection uses the encrypt-then-MAC
+    construct for CBC cipher suites, will be False also if connection uses
+    RC4 or AEAD.
+
     @sort: __init__, read, readAsync, write, writeAsync, close, closeAsync,
     getCipherImplementation, getCipherName
     """
@@ -144,6 +149,11 @@ class TLSRecordLayer(object):
     def version(self, value):
         """Set the SSL protocol version of connection"""
         self._recordLayer.version = value
+
+    @property
+    def encryptThenMAC(self):
+        """Whether the connection uses Encrypt Then MAC (RFC 7366)"""
+        return self._recordLayer.encryptThenMAC
 
     def clearReadBuffer(self):
         self._readBuffer = b''

--- a/unit_tests/mocksock.py
+++ b/unit_tests/mocksock.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2015, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+import socket
+import errno
+class MockSocket(socket.socket):
+    def __init__(self, buf, maxRet=None, maxWrite=None, blockEveryOther=False):
+        self.index = 0
+        self.buf = buf
+        self.sent = []
+        self.closed = False
+        self.maxRet = maxRet
+        self.maxWrite = maxWrite
+        self.blockEveryOther = blockEveryOther
+        self.blockRead = False
+        self.blockWrite = False
+
+    def __repr__(self):
+        return "MockSocket(index={0}, buf={1!r}, sent={2!r})".format(
+                self.index, self.buf, self.sent)
+
+    def recv(self, size):
+        if self.closed:
+            raise ValueError("Read from closed socket")
+
+        if self.blockEveryOther:
+            if self.blockRead:
+                self.blockRead = False
+                raise socket.error(errno.EWOULDBLOCK)
+            else:
+                self.blockRead = True
+
+        if size == 0:
+            return bytearray(0)
+        if self.maxRet is not None and self.maxRet < size:
+            size = self.maxRet
+        if len(self.buf[self.index:]) == 0:
+            raise socket.error(errno.EWOULDBLOCK)
+        elif len(self.buf[self.index:]) < size:
+            ret = self.buf[self.index:]
+            self.index = len(self.buf)
+            return ret
+        else:
+            ret = self.buf[self.index:self.index+size]
+            self.index+=size
+            return ret
+
+    def send(self, data):
+        if self.closed:
+            raise ValueError("Write to closed socket")
+
+        if self.blockEveryOther:
+            if self.blockWrite:
+                self.blockWrite = False
+                raise socket.error(errno.EWOULDBLOCK)
+            else:
+                self.blockWrite = True
+
+        if self.maxWrite is None or len(data) < self.maxWrite:
+            self.sent.append(data)
+            return len(data)
+
+        self.sent.append(data[:self.maxWrite])
+        return self.maxWrite
+
+    def close(self):
+        self.closed = True

--- a/unit_tests/test_tlslite_handshakesettings.py
+++ b/unit_tests/test_tlslite_handshakesettings.py
@@ -152,3 +152,20 @@ class TestHandshakeSettings(unittest.TestCase):
 
         with self.assertRaises(AssertionError):
             hs.getCertificateTypes()
+
+    def test_useEncryptThenMAC(self):
+        hs = HandshakeSettings()
+        self.assertTrue(hs.useEncryptThenMAC)
+
+        hs.useEncryptThenMAC = False
+
+        n_hs = hs.validate()
+
+        self.assertFalse(n_hs.useEncryptThenMAC)
+
+    def test_useEncryptThenMAC_with_wrong_value(self):
+        hs = HandshakeSettings()
+        hs.useEncryptThenMAC = None
+
+        with self.assertRaises(ValueError):
+            hs.validate()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -8,13 +8,25 @@ try:
 except ImportError:
     import unittest
 from tlslite.messages import ClientHello, ServerHello, RecordHeader3, Alert, \
-        RecordHeader2
+        RecordHeader2, Message
 from tlslite.utils.codec import Parser
 from tlslite.constants import CipherSuite, CertificateType, ContentType, \
         AlertLevel, AlertDescription, ExtensionType
 from tlslite.extensions import SNIExtension, ClientCertTypeExtension, \
     SRPExtension, TLSExtension
 from tlslite.errors import TLSInternalError
+
+class TestMessage(unittest.TestCase):
+    def test___init__(self):
+        msg = Message(ContentType.application_data, bytearray(0))
+
+        self.assertEqual(ContentType.application_data, msg.contentType)
+        self.assertEqual(bytearray(0), msg.data)
+
+    def test_write(self):
+        msg = Message(0, bytearray(10))
+
+        self.assertEqual(bytearray(10), msg.write())
 
 class TestClientHello(unittest.TestCase):
     def test___init__(self):

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -15,12 +15,14 @@ except ImportError:
     import unittest.mock as mock
     from unittest.mock import call
 
+import os
 import socket
 import errno
 
-from tlslite.messages import Message
-from tlslite.recordlayer import RecordSocket
-from tlslite.constants import ContentType
+import tlslite.utils.cryptomath as cryptomath
+from tlslite.messages import Message, ApplicationData
+from tlslite.recordlayer import RecordSocket, ConnectionState, RecordLayer
+from tlslite.constants import ContentType, CipherSuite
 from unit_tests.mocksock import MockSocket
 from tlslite.errors import TLSRecordOverflow, TLSIllegalParameterException,\
         TLSAbruptCloseError
@@ -297,3 +299,424 @@ class TestRecordSocket(unittest.TestCase):
             break
 
         self.assertEqual(0, result)
+
+class TestConnectionState(unittest.TestCase):
+    def test___init__(self):
+        connState = ConnectionState()
+
+        self.assertIsNotNone(connState)
+        self.assertIsNone(connState.macContext)
+        self.assertIsNone(connState.encContext)
+        self.assertEqual(0, connState.seqnum)
+
+    def test_getSeqNumBytes(self):
+        connState = ConnectionState()
+
+        self.assertEqual(bytearray(b'\x00'*8), connState.getSeqNumBytes())
+        self.assertEqual(bytearray(b'\x00'*7 + b'\x01'),
+                         connState.getSeqNumBytes())
+        self.assertEqual(bytearray(b'\x00'*7 + b'\x02'),
+                         connState.getSeqNumBytes())
+        self.assertEqual(bytearray(b'\x00'*7 + b'\x03'),
+                         connState.getSeqNumBytes())
+        self.assertEqual(4, connState.seqnum)
+
+class TestRecordLayer(unittest.TestCase):
+    def test___init__(self):
+        recordLayer = RecordLayer(None)
+
+        self.assertIsNotNone(recordLayer)
+
+    def test_sendMessage(self):
+        sock = MockSocket(bytearray(0))
+        recordLayer = RecordLayer(sock)
+
+        hello = Message(ContentType.handshake, bytearray(10))
+
+        for result in recordLayer.sendMessage(hello):
+            if result in (0, 1):
+                self.assertTrue(False, "Blocking write")
+            else:
+                break
+
+        self.assertEqual(len(sock.sent), 1)
+
+
+    def test_sendMessage_with_encrypting_set_up_tls1_2(self):
+        patcher = mock.patch.object(os,
+                                    'urandom',
+                                    lambda x: bytearray(x))
+        mock_random = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 3)
+
+        recordLayer.calcPendingStates(CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x03' +       # TLS1.2
+            b'\x00\x30'         # length - 48 bytes (3 blocks)
+            ))                  # (4 bytes of data + 20 bytes of MAC + IV)
+        self.assertEqual(bytearray(
+            b'\x48\x26\x1f\xc1\x9c\xde\x22\x92\xdd\xe4\x7c\xfc\x6f\x29\x52\xd6'+
+            b'\xc5\xec\x44\x21\xca\xe3\xd1\x34\x64\xad\xff\xb1\xea\xfa\xd5\xe3'+
+            b'\x9f\x73\xec\xa9\xa6\x82\x55\x8e\x3a\x8c\x94\x96\xda\x06\x09\x8d'
+            ), sock.sent[0][5:])
+
+    def test_sendMessage_with_SHA256_tls1_2(self):
+        patcher = mock.patch.object(os,
+                                    'urandom',
+                                    lambda x: bytearray(x))
+        mock_random = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 3)
+
+        recordLayer.calcPendingStates(
+                CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
+                bytearray(48), # master secret
+                bytearray(32), # client random
+                bytearray(32), # server random
+                None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x03' +       # TLS1.2
+            b'\x00\x40'         # length - 64 bytes (4 blocks)
+            ))                  # (4 bytes of data + 32 bytes of MAC + IV)
+        self.assertEqual(bytearray(
+            b'pd\x87\xde\xab\x9aU^\x7f\x7f\xa9\x00\xd14\'\x0c' +
+            b'\xde\xa73r\x9f\xb0O\x0eo_\x93\xec-\xb1c^' +
+            b'\x9a{\xde7g=\xef\x94\xd9K\xcc\x92\xe8\xa6\x10R' +
+            b'\xe0"c:7\xa9\xd7}X\x00[\x88\xce\xfe|\t'
+            ), sock.sent[0][5:])
+
+    def test_sendMessage_with_encrypting_set_up_tls1_1(self):
+        patcher = mock.patch.object(os,
+                                    'urandom',
+                                    lambda x: bytearray(x))
+        mock_random = patcher.start()
+        self.addCleanup(patcher.stop)
+
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 2)
+
+        recordLayer.calcPendingStates(CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x02' +       # TLS1.2
+            b'\x00\x30'         # length - 48 bytes (3 blocks)
+            ))                  # (4 bytes of data + 20 bytes of MAC + IV)
+        self.assertEqual(bytearray(
+            b'b\x8e\xee\xddV\\W=\x810\xd5\x0c\xae \x84\xa8' +
+            b'^\x91\xa4d[\xe4\xde\x90\xee{f\xbb\xcd_\x1ao' +
+            b'\xa8\x8c!k\xab\x03\x03\x19.\x1dFMt\x08h^'
+            ), sock.sent[0][5:])
+
+    def test_sendMessage_with_encrypting_set_up_tls1_0(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 1)
+
+        recordLayer.calcPendingStates(CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x01' +       # TLS1.0
+            b'\x00\x20'         # length - 48 bytes (3 blocks)
+            ))                  # (4 bytes of data + 20 bytes of MAC)
+        self.assertEqual(sock.sent[0][5:], bytearray(
+            b'\xebK\x0ff\x9cI\n\x011\xd0w\x9d\x11Z\xb4\xe5' +
+            b'D\xe9\xec\x8d\xdfd\xed\x94\x9f\xe6K\x08(\x08\xf6\xb7'
+            ))
+
+    def test_sendMessage_with_stream_cipher_and_tls1_0(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 1)
+
+        recordLayer.calcPendingStates(CipherSuite.TLS_RSA_WITH_RC4_128_SHA,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x01' +       # SSL3
+            b'\x00\x18'         # length - 24 bytes
+            ))                  # (4 bytes of data + 20 bytes of MAC)
+        self.assertEqual(sock.sent[0][5:], bytearray(
+            b'B\xb8H\xc6\xd7\\\x01\xe27\xa9\x86\xf2\xfdm!\x1d' +
+            b'\xa1\xaf]Q%y5\x1e'
+            ))
+
+    def test_sendMessage_with_MD5_MAC_and_tls1_0(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 1)
+
+        recordLayer.calcPendingStates(CipherSuite.TLS_RSA_WITH_RC4_128_MD5,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x01' +       # SSL3
+            b'\x00\x14'         # length - 20 bytes
+            ))                  # (4 bytes of data + 16 bytes of MAC)
+        self.assertEqual(sock.sent[0][5:], bytearray(
+            b'0}R\xe3T\xce`\xf9\x8f\x9d\xe6r\xc4\xdf\xd9\xd5' +
+            b'\xbf/sL'
+            ))
+
+
+    def test_sendMessage_with_AES256_cipher_and_tls1_0(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 1)
+
+        recordLayer.calcPendingStates(CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x01' +       # SSL3
+            b'\x00\x20'         # length - 32 bytes (2 blocks)
+            ))                  # (4 bytes of data + 20 bytes of MAC)
+        self.assertEqual(sock.sent[0][5:], bytearray(
+            b'\xb8\xe5\xc5\x9c\xe6\xad\xf0uY\x19L\x17\xf8\xe7F3' +
+            b'}\xcct\x84<j^\xdb\xa68\xd8\x08\x84pm\x97'
+            ))
+
+    # tlslite has no pure python implementation of 3DES
+    @unittest.skipUnless(cryptomath.m2cryptoLoaded or cryptomath.pycryptoLoaded,
+                         "requires native 3DES implementation")
+    def test_sendMessage_with_3DES_cipher_and_tls1_0(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 1)
+
+        recordLayer.calcPendingStates(CipherSuite.TLS_RSA_WITH_3DES_EDE_CBC_SHA,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x01' +       # SSL3
+            b'\x00\x20'         # length - 32 bytes (2 blocks)
+            ))                  # (4 bytes of data + 20 bytes of MAC)
+        self.assertEqual(sock.sent[0][5:], bytearray(
+            b'\xac\x12\xa55\x1a\x1f\xe2\xe5<\xb3[;\xc4\xa6\x9bF' +
+            b'\x8d\x16\x8b\xa3N\xe6\xfa\x14\xa9\xb9\xc7\x08w\xf2V\xe2'
+            ))
+
+    def test_sendMessage_with_encrypting_set_up_ssl3(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+        recordLayer.version = (3, 0)
+
+        recordLayer.calcPendingStates(CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                                      bytearray(48), # master secret
+                                      bytearray(32), # client random
+                                      bytearray(32), # server random
+                                      None)
+        recordLayer.changeWriteState()
+
+        app_data = ApplicationData().create(bytearray(b'test'))
+
+        self.assertIsNotNone(app_data)
+        self.assertTrue(len(app_data.write()) > 3)
+
+        for result in recordLayer.sendMessage(app_data, False):
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        self.assertEqual(len(sock.sent), 1)
+        self.assertEqual(sock.sent[0][:5], bytearray(
+            b'\x17' +           # application data
+            b'\x03\x00' +       # SSL3
+            b'\x00\x20'         # length - 48 bytes (3 blocks)
+            ))                  # (4 bytes of data + 20 bytes of MAC)
+        self.assertEqual(sock.sent[0][5:], bytearray(
+            b'\xc5\x16y\xf9\ra\xd9=\xec\x8b\x93\'\xb7\x05\xe6\xad' +
+            b'\xff\x842\xc7\xa2\x0byd\xab\x1a\xfd\xaf\x05\xd6\xba\x89'
+            ))
+
+    def test_sendMessage_with_wrong_SSL_version(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+
+        with self.assertRaises(AssertionError):
+            recordLayer.calcPendingStates(
+                    CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA,
+                    bytearray(48), # master secret
+                    bytearray(32), # client random
+                    bytearray(32), # server random
+                    None)
+
+    def test_sendMessage_with_invalid_ciphersuite(self):
+        sock = MockSocket(bytearray(0))
+
+        recordLayer = RecordLayer(sock)
+
+        with self.assertRaises(AssertionError):
+            recordLayer.calcPendingStates(
+                    CipherSuite.TLS_EMPTY_RENEGOTIATION_INFO_SCSV,
+                    bytearray(48), # master secret
+                    bytearray(32), # client random
+                    bytearray(32), # server random
+                    None)
+
+    def test_sendMessage_with_slow_socket(self):
+        mockSock = MockSocket(bytearray(0), maxWrite=1, blockEveryOther=True)
+        sock = RecordLayer(mockSock)
+
+        msg = Message(ContentType.handshake, bytearray(b'\x32'*2))
+
+        gotRetry = False
+        for result in sock.sendMessage(msg):
+            if result in (0, 1):
+                gotRetry = True
+            else: break
+
+        self.assertTrue(gotRetry)
+        self.assertEqual([
+            bytearray(b'\x16'),  # handshake message
+            bytearray(b'\x00'), bytearray(b'\x00'), # version (unset)
+            bytearray(b'\x00'), bytearray(b'\x02'), # payload length
+            bytearray(b'\x32'), bytearray(b'\x32')],
+            mockSock.sent)

--- a/unit_tests/test_tlslite_recordlayer.py
+++ b/unit_tests/test_tlslite_recordlayer.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2014, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+try:
+    import mock
+    from mock import call
+except ImportError:
+    import unittest.mock as mock
+    from unittest.mock import call
+
+import socket
+import errno
+
+from tlslite.messages import Message
+from tlslite.recordlayer import RecordSocket
+from tlslite.constants import ContentType
+from unit_tests.mocksock import MockSocket
+from tlslite.errors import TLSRecordOverflow, TLSIllegalParameterException,\
+        TLSAbruptCloseError
+
+class TestRecordSocket(unittest.TestCase):
+    def test___init__(self):
+        sock = RecordSocket(-42)
+
+        self.assertIsNotNone(sock)
+        self.assertEqual(sock.sock, -42)
+        self.assertEqual(sock.version, (0, 0))
+
+    def test_send(self):
+        mockSock = MockSocket(bytearray(0))
+        sock = RecordSocket(mockSock)
+        sock.version = (3, 3)
+
+        msg = Message(ContentType.handshake, bytearray(10))
+
+        for result in sock.send(msg):
+            if result in (0, 1):
+                self.assertTrue(False, "Blocking socket")
+            else: break
+
+        self.assertEqual(len(mockSock.sent), 1)
+        self.assertEqual(bytearray(
+            b'\x16' +           # handshake message
+            b'\x03\x03' +       # version
+            b'\x00\x0a' +       # payload length
+            b'\x00'*10          # payload
+            ), mockSock.sent[0])
+
+    def test_send_with_very_slow_socket(self):
+        mockSock = MockSocket(bytearray(0), maxWrite=1, blockEveryOther=True)
+        sock = RecordSocket(mockSock)
+
+        msg = Message(ContentType.handshake, bytearray(b'\x32'*2))
+
+        gotRetry = False
+        for result in sock.send(msg):
+            if result in (0, 1):
+                gotRetry = True
+            else: break
+
+        self.assertTrue(gotRetry)
+        self.assertEqual([
+            bytearray(b'\x16'),  # handshake message
+            bytearray(b'\x00'), bytearray(b'\x00'), # version (unset)
+            bytearray(b'\x00'), bytearray(b'\x02'), # payload length
+            bytearray(b'\x32'), bytearray(b'\x32')],
+            mockSock.sent)
+
+    def test_send_with_errored_out_socket(self):
+        mockSock = mock.MagicMock()
+        mockSock.send.side_effect = socket.error(errno.ETIMEDOUT)
+
+        sock = RecordSocket(mockSock)
+
+        msg = Message(ContentType.handshake, bytearray(10))
+
+        gen = sock.send(msg)
+
+        with self.assertRaises(socket.error):
+            next(gen)
+
+    def test_recv(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x04' +       # length
+            b'\x00'*4
+            ))
+        sock = RecordSocket(mockSock)
+
+        for result in sock.recv():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        header, data = result
+
+        self.assertEqual(data, bytearray(4))
+        self.assertEqual(header.type, ContentType.handshake)
+        self.assertEqual(header.version, (3, 3))
+        self.assertEqual(header.length, 4)
+
+    def test_recv_stops_itelf(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x04' +       # length
+            b'\x00'*4
+            ))
+        sock = RecordSocket(mockSock)
+
+        for result in sock.recv():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+
+        header, data = result
+
+        self.assertEqual(data, bytearray(4))
+        self.assertEqual(header.type, ContentType.handshake)
+        self.assertEqual(header.version, (3, 3))
+        self.assertEqual(header.length, 4)
+
+    def test_recv_with_trickling_socket(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x04' +       # length
+            b'\x00'*4
+            ), maxRet=1)
+
+        sock = RecordSocket(mockSock)
+
+        for result in sock.recv():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        header, data = result
+
+        self.assertEqual(bytearray(4), data)
+
+    def test_recv_with_blocking_socket(self):
+        mockSock = mock.MagicMock()
+        mockSock.recv.side_effect = socket.error(errno.EWOULDBLOCK)
+
+        sock = RecordSocket(mockSock)
+
+        gen = sock.recv()
+
+        self.assertEqual(0, next(gen))
+
+    def test_recv_with_errored_out_socket(self):
+        mockSock = mock.MagicMock()
+        mockSock.recv.side_effect = socket.error(errno.ETIMEDOUT)
+
+        sock = RecordSocket(mockSock)
+
+        gen = sock.recv()
+
+        with self.assertRaises(socket.error):
+            next(gen)
+
+    def test_recv_with_empty_socket(self):
+        mockSock = mock.MagicMock()
+        mockSock.recv.side_effect = [bytearray(0)]
+
+        sock = RecordSocket(mockSock)
+
+        gen = sock.recv()
+
+        with self.assertRaises(TLSAbruptCloseError):
+            next(gen)
+
+    def test_recv_with_slow_socket(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x04' +       # length
+            b'\x00'*4
+            ), maxRet=1, blockEveryOther=True)
+
+        sock = RecordSocket(mockSock)
+
+        gotRetry = False
+        for result in sock.recv():
+            if result in (0, 1):
+                gotRetry = True
+            else: break
+
+        header, data = result
+
+        self.assertTrue(gotRetry)
+        self.assertEqual(bytearray(4), data)
+
+    def test_recv_with_malformed_record(self):
+        mockSock = MockSocket(bytearray(
+            b'\x01' +           # wrong type
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x01' +       # length
+            b'\x00'))
+
+        sock = RecordSocket(mockSock)
+
+        gen = sock.recv()
+
+        with self.assertRaises(TLSIllegalParameterException):
+            next(gen)
+
+    def test_recv_with_too_big_record(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\xff\xff' +       # length
+            b'\x00'*65536))
+
+        sock = RecordSocket(mockSock)
+
+        gen = sock.recv()
+
+        with self.assertRaises(TLSRecordOverflow):
+            next(gen)
+
+
+    def test_recv_with_empty_data(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x00'))       # length
+
+        sock = RecordSocket(mockSock)
+
+        gen = sock.recv()
+
+        for result in sock.recv():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        header, data = result
+
+        self.assertEqual(ContentType.handshake, header.type)
+        self.assertEqual((3, 3), header.version)
+        self.assertEqual(0, header.length)
+
+        self.assertEqual(bytearray(0), data)
+
+    def test_recv_with_SSL2_record(self):
+        mockSock = MockSocket(bytearray(
+            b'\x80' +           # tag
+            b'\x04' +           # length
+            b'\x00'*4))
+
+        sock = RecordSocket(mockSock)
+
+        for result in sock.recv():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        header, data = result
+
+        self.assertTrue(header.ssl2)
+        self.assertEqual(ContentType.handshake, header.type)
+        self.assertEqual(4, header.length)
+        self.assertEqual((2, 0), header.version)
+
+        self.assertEqual(bytearray(4), data)
+
+    def test_recv_with_not_complete_SSL2_record(self):
+        mockSock = MockSocket(bytearray(
+            b'\x80' +           # tag
+            b'\x04' +           # length
+            b'\x00'*3))
+
+        sock = RecordSocket(mockSock)
+
+        for result in sock.recv():
+            break
+
+        self.assertEqual(0, result)
+
+    def test_recv_with_SSL2_record_with_incomplete_header(self):
+        mockSock = MockSocket(bytearray(
+            b'\x80'             # tag
+            ))
+
+        sock = RecordSocket(mockSock)
+
+        for result in sock.recv():
+            break
+
+        self.assertEqual(0, result)

--- a/unit_tests/test_tlslite_tlsrecordlayer.py
+++ b/unit_tests/test_tlslite_tlsrecordlayer.py
@@ -1,0 +1,297 @@
+# Copyright (c) 2014, Hubert Kario
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+# compatibility with Python 2.6, for that we need unittest2 package,
+# which is not available on 3.3 or 3.4
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+try:
+    import mock
+    from mock import call
+except ImportError:
+    import unittest.mock as mock
+    from unittest.mock import call
+
+import socket
+import errno
+from tlslite.tlsrecordlayer import TLSRecordLayer
+from tlslite.constants import ContentType
+from tlslite.errors import TLSAbruptCloseError, TLSLocalAlert
+from tlslite.messages import Message
+from unit_tests.mocksock import MockSocket
+
+class TestTLSRecordLayer(unittest.TestCase):
+    def test___init__(self):
+        record_layer = TLSRecordLayer(None)
+
+        self.assertIsNotNone(record_layer)
+        self.assertIsInstance(record_layer, TLSRecordLayer)
+
+    def test__getNextRecord(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x04' +       # length
+            b'\x00'*4
+            ))
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        for result in sock._getNextRecord():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        header, data = result
+        data = data.bytes
+
+        self.assertEqual(data, bytearray(4))
+        self.assertEqual(header.type, ContentType.handshake)
+        self.assertEqual(header.version, (3, 3))
+        self.assertEqual(header.length, 4)
+
+    def test__getNextRecord_stops_itelf(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x04' +       # length
+            b'\x00'*4
+            ))
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        for result in sock._getNextRecord():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+
+        header, data = result
+        data = data.bytes
+
+        self.assertEqual(data, bytearray(4))
+        self.assertEqual(header.type, ContentType.handshake)
+        self.assertEqual(header.version, (3, 3))
+        self.assertEqual(header.length, 4)
+
+    def test__getNextRecord_with_trickling_socket(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x04' +       # length
+            b'\x00'*4
+            ), maxRet=1)
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        for result in sock._getNextRecord():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        header, data = result
+        data = data.bytes
+
+        self.assertEqual(bytearray(4), data)
+
+    def test__getNextRecord_with_blocking_socket(self):
+        mockSock = mock.MagicMock()
+        mockSock.recv.side_effect = socket.error(errno.EWOULDBLOCK)
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        gen = sock._getNextRecord()
+
+        self.assertEqual(0, next(gen))
+
+    def test__getNextRecord_with_errored_out_socket(self):
+        mockSock = mock.MagicMock()
+        mockSock.recv.side_effect = socket.error(errno.ETIMEDOUT)
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        gen = sock._getNextRecord()
+
+        with self.assertRaises(socket.error):
+            next(gen)
+
+    def test__getNextRecord_with_empty_socket(self):
+        mockSock = mock.MagicMock()
+        mockSock.recv.side_effect = [bytearray(0)]
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        gen = sock._getNextRecord()
+
+        with self.assertRaises(TLSAbruptCloseError):
+            next(gen)
+
+    def test__getNextRecord_with_slow_socket(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x04' +       # length
+            b'\x00'*4
+            ), maxRet=1, blockEveryOther=True)
+
+        sock = TLSRecordLayer(mockSock)
+
+        gotRetry = False
+        # XXX using private method!
+        for result in sock._getNextRecord():
+            if result in (0, 1):
+                gotRetry = True
+            else: break
+
+        header, data = result
+        data = data.bytes
+
+        self.assertTrue(gotRetry)
+        self.assertEqual(bytearray(4), data)
+
+    def test__getNextRecord_with_malformed_record(self):
+        mockSock = MockSocket(bytearray(
+            b'\x01' +           # wrong type
+            b'\x03\x03' +       # TLSv1.2
+            b'\x00\x01' +       # length
+            b'\x00'))
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        gen = sock._getNextRecord()
+
+        # XXX this should be TLSLocalAlert as we're expected to tell the other
+        # side they have sent us garbage
+        with self.assertRaises(SyntaxError) as context:
+            next(gen)
+
+        #self.assertEqual(str(context.exception), "illegal_parameter")
+
+    def test__getNextRecord_with_too_big_record(self):
+        mockSock = MockSocket(bytearray(
+            b'\x16' +           # type - handshake
+            b'\x03\x03' +       # TLSv1.2
+            b'\xff\xff' +       # length
+            b'\x00'*65536))
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        gen = sock._getNextRecord()
+
+        with self.assertRaises(TLSLocalAlert) as context:
+            next(gen)
+
+        self.assertEqual(str(context.exception), "record_overflow")
+
+    def test__getNextRecord_with_SSL2_record(self):
+        mockSock = MockSocket(bytearray(
+            b'\x80' +           # tag
+            b'\x04' +           # length
+            b'\x00'*4))
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        for result in sock._getNextRecord():
+            if result in (0, 1):
+                self.assertTrue(False, "blocking socket")
+            else: break
+
+        header, data = result
+        data = data.bytes
+
+        self.assertTrue(header.ssl2)
+        self.assertEqual(ContentType.handshake, header.type)
+        self.assertEqual(4, header.length)
+        self.assertEqual((2, 0), header.version)
+
+        self.assertEqual(bytearray(4), data)
+
+    def test__getNextRecord_with_not_complete_SSL2_record(self):
+        mockSock = MockSocket(bytearray(
+            b'\x80' +           # tag
+            b'\x04' +           # length
+            b'\x00'*3))
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method!
+        for result in sock._getNextRecord():
+            break
+
+        self.assertEqual(0, result)
+
+    def test__getNextRecord_with_SSL2_record_with_incomplete_header(self):
+        mockSock = MockSocket(bytearray(
+            b'\x80'             # tag
+            ))
+
+        sock = TLSRecordLayer(mockSock)
+
+        # XXX using private method
+        for result in sock._getNextRecord():
+            break
+
+        self.assertEqual(0, result)
+
+    def test__sendMsg(self):
+        mockSock = MockSocket(bytearray(0))
+        sock = TLSRecordLayer(mockSock)
+        sock.version = (3, 3)
+
+        msg = Message(ContentType.handshake, bytearray(10))
+
+        # XXX using private method
+        for result in sock._sendMsg(msg, False):
+            if result in (0, 1):
+                self.assertTrue(False, "Blocking socket")
+            else: break
+
+        self.assertEqual(len(mockSock.sent), 1)
+        self.assertEqual(bytearray(
+            b'\x16' +           # handshake message
+            b'\x03\x03' +       # version
+            b'\x00\x0a' +       # payload length
+            b'\x00'*10          # payload
+            ), mockSock.sent[0])
+
+    def test__sendMsg_with_very_slow_socket(self):
+        mockSock = MockSocket(bytearray(0), maxWrite=1, blockEveryOther=True)
+        sock = TLSRecordLayer(mockSock)
+
+        msg = Message(ContentType.handshake, bytearray(b'\x32'*2))
+
+        gotRetry = False
+        # XXX using private method!
+        for result in sock._sendMsg(msg, False):
+            if result in (0, 1):
+                gotRetry = True
+            else: break
+
+        self.assertTrue(gotRetry)
+        self.assertEqual([
+            bytearray(b'\x16'),  # handshake message
+            bytearray(b'\x00'), bytearray(b'\x00'), # version (unset)
+            bytearray(b'\x00'), bytearray(b'\x02'), # payload length
+            bytearray(b'\x32'), bytearray(b'\x32')],
+            mockSock.sent)
+
+    def test__sendMsg_with_errored_out_socket(self):
+        mockSock = mock.MagicMock()
+        mockSock.send.side_effect = socket.error(errno.ETIMEDOUT)
+
+        sock = TLSRecordLayer(mockSock)
+
+        msg = Message(ContentType.handshake, bytearray(10))
+
+        gen = sock._sendMsg(msg, False)
+
+        with self.assertRaises(TLSAbruptCloseError):
+            next(gen)

--- a/unit_tests/test_tlslite_tlsrecordlayer.py
+++ b/unit_tests/test_tlslite_tlsrecordlayer.py
@@ -166,12 +166,10 @@ class TestTLSRecordLayer(unittest.TestCase):
         # XXX using private method!
         gen = sock._getNextRecord()
 
-        # XXX this should be TLSLocalAlert as we're expected to tell the other
-        # side they have sent us garbage
-        with self.assertRaises(SyntaxError) as context:
+        with self.assertRaises(TLSLocalAlert) as context:
             next(gen)
 
-        #self.assertEqual(str(context.exception), "illegal_parameter")
+        self.assertEqual(str(context.exception), "illegal_parameter")
 
     def test__getNextRecord_with_too_big_record(self):
         mockSock = MockSocket(bytearray(


### PR DESCRIPTION
Implements the encrypt then MAC mechanism for CBC based cipher suites in TLS from RFC 7366.

Missing:
- client side check for EtM advertised in server hello together with stream or AEAD cipher (it's incorrect use and it will fail to interoperate anyway but won't report correct errors - I'd rather test it using mechanism introduced in #47)
- ability to force use of EtM (abort connection when server didn't select EtM but did select CBC cipher suite - that will need to wait for AEAD to be actually useful)

Tested against nikos.codelas.eu:4443 (GnuTLS)

Changes since v3:
- rebased on record-layer-refactor, pull #94 
- changed name of setting from `etm` to `encryptThenMAC`
- nicer check for RC4 ciphers on server side
- some code sharing with the regular MAC then encrypt mechanism
- 100% test coverage for encrypt-then-MAC and MAC-then-decrypt functions
- handling of session resumption with EtM (including correctly abort if client doesn't advertise etm but old session included it)

Changes since v2:
- reworked "move MAC-then-encrypt", "etm decryption" and "etm decryption" to fix most pylint complaints
- rebased on master

Changes since v1:
- reworked "etm decryption" and "etm encryption" patches to better show what is happening, unfortunately the "move MAC-then-encrypt to separate methods" is still rather hard to read, but it's not really possible to make it any better
- rebased on master with fixed tests

Obsoletes #79 
