### PR TITLE
[v2] Ugly^W Minimal record layer refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,11 +44,20 @@ matrix:
 
 before_install:
   - |
+       echo -e "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST\n" \
+               "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG\n" \
+               "TRAVIS_PULL_REQUEST=$TRAVIS_PULL_REQUEST\n" \
+               "TRAVIS_COMMIT=$TRAVIS_COMMIT\n" \
+               "TRAVIS_PYTHON_VERSION=$TRAVIS_PYTHON_VERSION"
+  - |
        # workaround https://github.com/travis-ci/travis-ci/issues/2666
        if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-         PR_FIRST=$(curl -s https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST}.patch | head -1 | grep -o -E '\b[0-9a-f]{40}\b' | tr -d '\n')
+         URL="https://github.com/${TRAVIS_REPO_SLUG}/pull/${TRAVIS_PULL_REQUEST}.patch"
+         # `--location` makes curl follow redirects
+         PR_FIRST=$(curl --silent --show-error --location $URL | head -1 | grep -o -E '\b[0-9a-f]{40}\b' | tr -d '\n')
          TRAVIS_COMMIT_RANGE=$PR_FIRST^..$TRAVIS_COMMIT
        fi
+  - echo "TRAVIS_COMMIT_RANGE=$TRAVIS_COMMIT_RANGE"
   - git fetch origin master:refs/remotes/origin/master
 
 install:

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -175,3 +175,7 @@ class TLSUnsupportedError(TLSError):
 class TLSInternalError(TLSError):
     """The internal state of object is unexpected or invalid"""
     pass
+
+class TLSRecordOverflow(TLSInternalError):
+    """Read record is too big to handle"""
+    pass

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -187,3 +187,9 @@ class TLSDecryptionFailed(TLSInternalError):
 class TLSBadRecordMAC(TLSInternalError):
     """MAC or padding of record was invalid"""
     pass
+
+class TLSSocketClosed(TLSInternalError):
+    """Socket was closed unexpectedly while writing messages"""
+    def __init__(self, reason):
+        super(TLSSocketClosed, self).__init__()
+        self.reason = reason

--- a/tlslite/errors.py
+++ b/tlslite/errors.py
@@ -179,3 +179,11 @@ class TLSInternalError(TLSError):
 class TLSRecordOverflow(TLSInternalError):
     """Read record is too big to handle"""
     pass
+
+class TLSDecryptionFailed(TLSInternalError):
+    """Decryptioin was impossible"""
+    pass
+
+class TLSBadRecordMAC(TLSInternalError):
+    """MAC or padding of record was invalid"""
+    pass

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -636,10 +636,10 @@ class TLSConnection(TLSRecordLayer):
                     yield result
 
             #Calculate pending connection states
-            self._calcPendingStates(session.cipherSuite, 
-                                    session.masterSecret, 
-                                    clientRandom, serverHello.random, 
-                                    cipherImplementations)                                   
+            self.calcPendingStates(session.cipherSuite,
+                                   session.masterSecret,
+                                   clientRandom, serverHello.random,
+                                   cipherImplementations)
 
             #Exchange ChangeCipherSpec and Finished messages
             for result in self._getFinished(session.masterSecret):
@@ -916,9 +916,9 @@ class TLSConnection(TLSRecordLayer):
 
         masterSecret = calcMasterSecret(self.version, premasterSecret,
                             clientRandom, serverRandom)
-        self._calcPendingStates(cipherSuite, masterSecret, 
-                                clientRandom, serverRandom, 
-                                cipherImplementations)
+        self.calcPendingStates(cipherSuite, masterSecret,
+                               clientRandom, serverRandom,
+                               cipherImplementations)
 
         #Exchange ChangeCipherSpec and Finished messages
         for result in self._sendFinished(masterSecret, nextProto):
@@ -1319,11 +1319,11 @@ class TLSConnection(TLSRecordLayer):
                 self._versionCheck = True
 
                 #Calculate pending connection states
-                self._calcPendingStates(session.cipherSuite, 
-                                        session.masterSecret,
-                                        clientHello.random, 
-                                        serverHello.random,
-                                        settings.cipherImplementations)
+                self.calcPendingStates(session.cipherSuite,
+                                       session.masterSecret,
+                                       clientHello.random,
+                                       serverHello.random,
+                                       settings.cipherImplementations)
 
                 #Exchange ChangeCipherSpec and Finished messages
                 for result in self._sendFinished(session.masterSecret):
@@ -1617,9 +1617,9 @@ class TLSConnection(TLSRecordLayer):
                                       clientRandom, serverRandom)
         
         #Calculate pending connection states
-        self._calcPendingStates(cipherSuite, masterSecret, 
-                                clientRandom, serverRandom,
-                                cipherImplementations)
+        self.calcPendingStates(cipherSuite, masterSecret,
+                               clientRandom, serverRandom,
+                               cipherImplementations)
 
         #Exchange ChangeCipherSpec and Finished messages
         for result in self._getFinished(masterSecret, 
@@ -1643,7 +1643,7 @@ class TLSConnection(TLSRecordLayer):
             yield result
 
         #Switch to pending write state
-        self._changeWriteState()
+        self.changeWriteState()
 
         if nextProto is not None:
             nextProtoMsg = NextProtocol().create(nextProto)
@@ -1673,7 +1673,7 @@ class TLSConnection(TLSRecordLayer):
                 yield result
 
         #Switch to pending read state
-        self._changeReadState()
+        self.changeReadState()
 
         #Server Finish - Are we waiting for a next protocol echo? 
         if expect_next_protocol:

--- a/tlslite/tlsrecordlayer.py
+++ b/tlslite/tlsrecordlayer.py
@@ -565,7 +565,7 @@ class TLSRecordLayer(object):
             self._handshake_sha256.update(compat26Str(byteArray))
 
         try:
-            for result in self._sendRecord(msg):
+            for result in self.sendRecord(msg):
                 yield result
         except TLSSocketClosed as why:
             # The socket was unexpectedly closed.  The tricky part
@@ -600,7 +600,7 @@ class TLSRecordLayer(object):
                 # raise the socket.error
                 raise why.reason
 
-    def _sendRecord(self, msg):
+    def sendRecord(self, msg):
         """Send a TLS message in the record layer, encrypt if handshake done"""
 
         byteArray = msg.write()
@@ -834,7 +834,7 @@ class TLSRecordLayer(object):
                 yield result
 
 
-    def _getRecord(self):
+    def getRecord(self):
         """Reads a single record layer message from socket"""
 
         #Read the next record header
@@ -935,7 +935,7 @@ class TLSRecordLayer(object):
 
         #Otherwise...
         try:
-            for result in self._getRecord():
+            for result in self.getRecord():
                 if result in (0, 1):
                     yield result
                 else:
@@ -1094,7 +1094,7 @@ class TLSRecordLayer(object):
         self.resumed = resumed
         self.closed = False
 
-    def _calcPendingStates(self, cipherSuite, masterSecret,
+    def calcPendingStates(self, cipherSuite, masterSecret,
             clientRandom, serverRandom, implementations):
         if cipherSuite in CipherSuite.aes128Suites:
             keyLength = 16
@@ -1184,11 +1184,11 @@ class TLSRecordLayer(object):
             #residue to create the IV for each sent block)
             self.fixedIVBlock = getRandomBytes(ivLength)
 
-    def _changeWriteState(self):
+    def changeWriteState(self):
         self._writeState = self._pendingWriteState
         self._pendingWriteState = _ConnectionState()
 
-    def _changeReadState(self):
+    def changeReadState(self):
         self._readState = self._pendingReadState
         self._pendingReadState = _ConnectionState()
 


### PR DESCRIPTION
Refactor record layer to expose low level methods to send and receive TLS messages. It's not _really_ minimal, as to make it pass `pylint` checks I had to clean up the code at least a bit (variable names and whitespace) to pass the 90% mark.

Alternative version of pull #94, but without majority of code cleanup and changes made in preparation to EtM support.

Changes since v1:
- rebase on top of pull #101 to fix Travis-CI failures
