### PR TITLE
[v2] Fix public field names

### DIFF
--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -40,15 +40,15 @@ class TLSExtension(object):
         ID. Contains ClientHello version of extensions or universal
         implementations
 
-    @type _server_extensions: dict
-    @cvar _server_extensions: dictionary with concrete implementations of
+    @type _serverExtensions: dict
+    @cvar _serverExtensions: dictionary with concrete implementations of
         specific TLS extensions where key is the numeric value of the extension
         ID. Includes only those extensions that require special handlers for
         ServerHello versions.
     """
     # actual definition at the end of file, after definitions of all classes
     _universalExtensions = {}
-    _server_extensions = {}
+    _serverExtensions = {}
 
     def __init__(self, server=False):
         """
@@ -117,8 +117,8 @@ class TLSExtension(object):
         ext_length = p.get(2)
 
         # first check if we shouldn't use server side parser
-        if self.serverType and extType in self._server_extensions:
-            ext = self._server_extensions[extType]()
+        if self.serverType and extType in self._serverExtensions:
+            ext = self._serverExtensions[extType]()
             ext_parser = Parser(p.getFixBytes(ext_length))
             ext = ext.parse(ext_parser)
             return ext
@@ -918,6 +918,6 @@ TLSExtension._universalExtensions = {
         ExtensionType.srp : SRPExtension,
         ExtensionType.supports_npn : NPNExtension}
 
-TLSExtension._server_extensions = {
+TLSExtension._serverExtensions = {
         ExtensionType.cert_type : ServerCertTypeExtension,
         ExtensionType.tack : TACKExtension}

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -21,8 +21,8 @@ class TLSExtension(object):
     It is used as a base class for specific users and as a way to store
     extensions that are not implemented in library.
 
-    @type ext_type: int
-    @ivar ext_type: a 2^16-1 limited integer specifying the type of the
+    @type extType: int
+    @ivar extType: a 2^16-1 limited integer specifying the type of the
         extension that it contains, e.g. 0 indicates server name extension
 
     @type ext_data: bytearray
@@ -62,23 +62,23 @@ class TLSExtension(object):
         @param server: whatever to select ClientHello or ServerHello version
             for parsing
         """
-        self.ext_type = None
+        self.extType = None
         self.ext_data = bytearray(0)
         self.server_type = server
 
-    def create(self, ext_type, data):
+    def create(self, extType, data):
         """
         Initializes a generic TLS extension that can later be used in
         client hello or server hello messages
 
-        @type  ext_type: int
-        @param ext_type: type of the extension encoded as an integer between
+        @type  extType: int
+        @param extType: type of the extension encoded as an integer between
             M{0} and M{2^16-1}
         @type  data: bytearray
         @param data: raw data representing extension on the wire
         @rtype: L{TLSExtension}
         """
-        self.ext_type = ext_type
+        self.extType = extType
         self.ext_data = data
         return self
 
@@ -93,10 +93,10 @@ class TLSExtension(object):
         @raise AssertionError: when the object was not initialized
         """
 
-        assert self.ext_type is not None
+        assert self.extType is not None
 
         w = Writer()
-        w.add(self.ext_type, 2)
+        w.add(self.extType, 2)
         w.add(len(self.ext_data), 2)
         w.addFixSeq(self.ext_data, 1)
         return w.bytes
@@ -113,26 +113,26 @@ class TLSExtension(object):
         @rtype: L{TLSExtension}
         """
 
-        ext_type = p.get(2)
+        extType = p.get(2)
         ext_length = p.get(2)
 
         # first check if we shouldn't use server side parser
-        if self.server_type and ext_type in self._server_extensions:
-            ext = self._server_extensions[ext_type]()
+        if self.server_type and extType in self._server_extensions:
+            ext = self._server_extensions[extType]()
             ext_parser = Parser(p.getFixBytes(ext_length))
             ext = ext.parse(ext_parser)
             return ext
 
         # then fallback to universal/ClientHello-specific parsers
-        if ext_type in self._universal_extensions:
-            ext = self._universal_extensions[ext_type]()
+        if extType in self._universal_extensions:
+            ext = self._universal_extensions[extType]()
             ext_parser = Parser(p.getFixBytes(ext_length))
             ext = ext.parse(ext_parser)
             return ext
 
         # finally, just save the extension data as there are extensions which
         # don't require specific handlers and indicate option by mere presence
-        self.ext_type = ext_type
+        self.extType = extType
         self.ext_data = p.getFixBytes(ext_length)
         assert len(self.ext_data) == ext_length
         return self
@@ -143,8 +143,8 @@ class TLSExtension(object):
 
         Will return False for every object that's not an extension.
         """
-        if hasattr(that, 'ext_type') and hasattr(that, 'ext_data'):
-            return self.ext_type == that.ext_type and \
+        if hasattr(that, 'extType') and hasattr(that, 'ext_data'):
+            return self.extType == that.extType and \
                     self.ext_data == that.ext_data
         else:
             return False
@@ -154,9 +154,9 @@ class TLSExtension(object):
 
         @rtype: str
         """
-        return "TLSExtension(ext_type={0!r}, ext_data={1!r},"\
-                " server_type={2!r})".format(
-                        self.ext_type, self.ext_data, self.server_type)
+        return "TLSExtension(extType={0!r}, ext_data={1!r},"\
+                " server_type={2!r})".format(self.extType, self.ext_data,
+                                             self.server_type)
 
 class SNIExtension(TLSExtension):
     """
@@ -194,8 +194,8 @@ class SNIExtension(TLSExtension):
         The list will be empty if the on the wire extension had and empty
         list while it will be None if the extension was empty.
 
-    @type ext_type: int
-    @ivar ext_type: numeric type of SNIExtension, i.e. 0
+    @type extType: int
+    @ivar extType: numeric type of SNIExtension, i.e. 0
 
     @type ext_data: bytearray
     @ivar ext_data: raw representation of the extension
@@ -264,7 +264,7 @@ class SNIExtension(TLSExtension):
         return self
 
     @property
-    def ext_type(self):
+    def extType(self):
         """ Return the type of TLS extension, in this case - 0
 
         @rtype: int
@@ -343,7 +343,7 @@ class SNIExtension(TLSExtension):
         raw_data = self.ext_data
 
         w = Writer()
-        w.add(self.ext_type, 2)
+        w.add(self.extType, 2)
         w.add(len(raw_data), 2)
         w.bytes += raw_data
 
@@ -381,8 +381,8 @@ class ClientCertTypeExtension(TLSExtension):
     This class handles the Certificate Type extension (variant sent by client)
     defined in RFC 6091.
 
-    @type ext_type: int
-    @ivar ext_type: numeric type of Certificate Type extension, i.e. 9
+    @type extType: int
+    @ivar extType: numeric type of Certificate Type extension, i.e. 9
 
     @type ext_data: bytearray
     @ivar ext_data: raw representation of the extension data
@@ -409,7 +409,7 @@ class ClientCertTypeExtension(TLSExtension):
                 .format(self.cert_types)
 
     @property
-    def ext_type(self):
+    def extType(self):
         """
         Return the type of TLS extension, in this case - 9
 
@@ -471,8 +471,8 @@ class ServerCertTypeExtension(TLSExtension):
     This class handles the Certificate Type extension (variant sent by server)
     defined in RFC 6091.
 
-    @type ext_type: int
-    @ivar ext_type: byneruc ttoe if Certificate Type extension, i.e. 9
+    @type extType: int
+    @ivar extType: byneruc ttoe if Certificate Type extension, i.e. 9
 
     @type ext_data: bytearray
     @ivar ext_data: raw representation of the extension data
@@ -498,7 +498,7 @@ class ServerCertTypeExtension(TLSExtension):
         return "ServerCertTypeExtension(cert_type={0!r})".format(self.cert_type)
 
     @property
-    def ext_type(self):
+    def extType(self):
         """
         Return the type of TLS extension, in this case - 9
 
@@ -547,8 +547,8 @@ class SRPExtension(TLSExtension):
     This class handles the Secure Remote Password protocol TLS extension
     defined in RFC 5054.
 
-    @type ext_type: int
-    @ivar ext_type: numeric type of SRPExtension, i.e. 12
+    @type extType: int
+    @ivar extType: numeric type of SRPExtension, i.e. 12
 
     @type ext_data: bytearray
     @ivar ext_data: raw representation of extension data
@@ -575,7 +575,7 @@ class SRPExtension(TLSExtension):
         return "SRPExtension(identity={0!r})".format(self.identity)
 
     @property
-    def ext_type(self):
+    def extType(self):
         """
         Return the type of TLS extension, in this case - 12
 
@@ -643,8 +643,8 @@ class NPNExtension(TLSExtension):
     @type protocols: list of bytearrays
     @ivar protocols: list of protocol names supported by the server
 
-    @type ext_type: int
-    @ivar ext_type: numeric type of NPNExtension, i.e. 13172
+    @type extType: int
+    @ivar extType: numeric type of NPNExtension, i.e. 13172
 
     @type ext_data: bytearray
     @ivar ext_data: raw representation of extension data
@@ -668,7 +668,7 @@ class NPNExtension(TLSExtension):
         return "NPNExtension(protocols={0!r})".format(self.protocols)
 
     @property
-    def ext_type(self):
+    def extType(self):
         """ Return the type of TLS extension, in this case - 13172
 
         @rtype: int
@@ -856,7 +856,7 @@ class TACKExtension(TLSExtension):
                 self.activation_flags, self.tacks)
 
     @property
-    def ext_type(self):
+    def extType(self):
         """
         Returns the type of TLS extension, in this case - 62208
 

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -169,20 +169,20 @@ class SNIExtension(TLSExtension):
     opaque byte strings, in case of DNS host names (records of type 0) they
     are UTF-8 encoded domain names (without the ending dot).
 
-    @type host_names: tuple of bytearrays
-    @ivar host_names: tuple of hostnames (server name records of type 0)
+    @type hostNames: tuple of bytearrays
+    @ivar hostNames: tuple of hostnames (server name records of type 0)
         advertised in the extension. Note that it may not include all names
         from client hello as the client can advertise other types. Also note
         that while it's not possible to change the returned array in place, it
         is possible to assign a new set of names. IOW, this won't work::
 
-           sni_extension.host_names[0] = bytearray(b'example.com')
+           sni_extension.hostNames[0] = bytearray(b'example.com')
 
         while this will work::
 
-           names = list(sni_extension.host_names)
+           names = list(sni_extension.hostNames)
            names[0] = bytearray(b'example.com')
-           sni_extension.host_names = names
+           sni_extension.hostNames = names
 
 
     @type serverNames: list of L{ServerName}
@@ -219,31 +219,31 @@ class SNIExtension(TLSExtension):
         """
         return "SNIExtension(serverNames={0!r})".format(self.serverNames)
 
-    def create(self, hostname=None, host_names=None, serverNames=None):
+    def create(self, hostname=None, hostNames=None, serverNames=None):
         """
         Initializes an instance with provided hostname, host names or
         raw server names.
 
         Any of the parameters may be None, in that case the list inside the
-        extension won't be defined, if either host_names or serverNames is
+        extension won't be defined, if either hostNames or serverNames is
         an empty list, then the extension will define a list of lenght 0.
 
         If multiple parameters are specified at the same time, then the
         resulting list of names will be concatenated in order of hostname,
-        host_names and serverNames last.
+        hostNames and serverNames last.
 
         @type  hostname: bytearray
         @param hostname: raw UTF-8 encoding of the host name
 
-        @type  host_names: list of bytearrays
-        @param host_names: list of raw UTF-8 encoded host names
+        @type  hostNames: list of bytearrays
+        @param hostNames: list of raw UTF-8 encoded host names
 
         @type  serverNames: list of L{ServerName}
         @param serverNames: pairs of name_type and name encoded as a namedtuple
 
         @rtype: L{SNIExtension}
         """
-        if hostname is None and host_names is None and serverNames is None:
+        if hostname is None and hostNames is None and serverNames is None:
             self.serverNames = None
             return self
         else:
@@ -253,10 +253,10 @@ class SNIExtension(TLSExtension):
             self.serverNames += [SNIExtension.ServerName(NameType.host_name,\
                     hostname)]
 
-        if host_names:
+        if hostNames:
             self.serverNames +=\
                     [SNIExtension.ServerName(NameType.host_name, x) for x in\
-                    host_names]
+                    hostNames]
 
         if serverNames:
             self.serverNames += serverNames
@@ -272,8 +272,8 @@ class SNIExtension(TLSExtension):
         return ExtensionType.server_name
 
     @property
-    def host_names(self):
-        """ Returns a simulated list of host_names from the extension.
+    def hostNames(self):
+        """ Returns a simulated list of hostNames from the extension.
 
         @rtype: tuple of bytearrays
         """
@@ -285,26 +285,26 @@ class SNIExtension(TLSExtension):
             return tuple([x.name for x in self.serverNames if \
                 x.name_type == NameType.host_name])
 
-    @host_names.setter
-    def host_names(self, host_names):
+    @hostNames.setter
+    def hostNames(self, hostNames):
         """ Removes all host names from the extension and replaces them by
-        names in X{host_names} parameter.
+        names in X{hostNames} parameter.
 
         Newly added parameters will be added at the I{beginning} of the list
         of extensions.
 
-        @type host_names: iterable of bytearrays
-        @param host_names: host names to replace the old server names of type 0
+        @type hostNames: iterable of bytearrays
+        @param hostNames: host names to replace the old server names of type 0
         """
 
         self.serverNames = \
                 [SNIExtension.ServerName(NameType.host_name, x) for x in \
-                    host_names] + \
+                    hostNames] + \
                 [x for x in self.serverNames if \
                     x.name_type != NameType.host_name]
 
-    @host_names.deleter
-    def host_names(self):
+    @hostNames.deleter
+    def hostNames(self):
         """ Remove all host names from extension, leaves other name types
         unmodified
         """

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -29,8 +29,8 @@ class TLSExtension(object):
     @ivar extData: a byte array containing the value of the extension as
         to be written on the wire
 
-    @type server_type: boolean
-    @ivar server_type: indicates that the extension was parsed with ServerHello
+    @type serverType: boolean
+    @ivar serverType: indicates that the extension was parsed with ServerHello
         specific parser, otherwise it used universal or ClientHello specific
         parser
 
@@ -64,7 +64,7 @@ class TLSExtension(object):
         """
         self.extType = None
         self.extData = bytearray(0)
-        self.server_type = server
+        self.serverType = server
 
     def create(self, extType, data):
         """
@@ -117,7 +117,7 @@ class TLSExtension(object):
         ext_length = p.get(2)
 
         # first check if we shouldn't use server side parser
-        if self.server_type and extType in self._server_extensions:
+        if self.serverType and extType in self._server_extensions:
             ext = self._server_extensions[extType]()
             ext_parser = Parser(p.getFixBytes(ext_length))
             ext = ext.parse(ext_parser)
@@ -155,8 +155,8 @@ class TLSExtension(object):
         @rtype: str
         """
         return "TLSExtension(extType={0!r}, extData={1!r},"\
-                " server_type={2!r})".format(self.extType, self.extData,
-                                             self.server_type)
+                " serverType={2!r})".format(self.extType, self.extData,
+                                            self.serverType)
 
 class SNIExtension(TLSExtension):
     """

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -387,8 +387,8 @@ class ClientCertTypeExtension(TLSExtension):
     @type extData: bytearray
     @ivar extData: raw representation of the extension data
 
-    @type cert_types: list of int
-    @ivar cert_types: list of certificate type identifiers (each one byte long)
+    @type certTypes: list of int
+    @ivar certTypes: list of certificate type identifiers (each one byte long)
     """
 
     def __init__(self):
@@ -398,15 +398,15 @@ class ClientCertTypeExtension(TLSExtension):
         See also: L{create} and L{parse}
         """
 
-        self.cert_types = None
+        self.certTypes = None
 
     def __repr__(self):
         """ Return programmer-centric representation of extension
 
         @rtype: str
         """
-        return "ClientCertTypeExtension(cert_types={0!r})"\
-                .format(self.cert_types)
+        return "ClientCertTypeExtension(certTypes={0!r})"\
+                .format(self.certTypes)
 
     @property
     def extType(self):
@@ -426,27 +426,27 @@ class ClientCertTypeExtension(TLSExtension):
         @rtype: bytearray
         """
 
-        if self.cert_types is None:
+        if self.certTypes is None:
             return bytearray(0)
 
         w = Writer()
-        w.add(len(self.cert_types), 1)
-        for c_type in self.cert_types:
+        w.add(len(self.certTypes), 1)
+        for c_type in self.certTypes:
             w.add(c_type, 1)
 
         return w.bytes
 
-    def create(self, cert_types=None):
+    def create(self, certTypes=None):
         """
         Return instance of this extension with specified certificate types
 
-        @type cert_types: iterable list of int
-        @param cert_types: list of certificate types to advertise, all values
+        @type certTypes: iterable list of int
+        @param certTypes: list of certificate types to advertise, all values
             should be between 0 and 2^8-1 inclusive
 
         @raises ValueError: when the list includes too big or negative integers
         """
-        self.cert_types = cert_types
+        self.certTypes = certTypes
         return self
 
     def parse(self, p):
@@ -462,7 +462,7 @@ class ClientCertTypeExtension(TLSExtension):
         @rtype: L{ClientCertTypeExtension}
         """
 
-        self.cert_types = p.getVarList(1, 1)
+        self.certTypes = p.getVarList(1, 1)
 
         return self
 

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -34,8 +34,8 @@ class TLSExtension(object):
         specific parser, otherwise it used universal or ClientHello specific
         parser
 
-    @type _universal_extensions: dict
-    @cvar _universal_extensions: dictionary with concrete implementations of
+    @type _universalExtensions: dict
+    @cvar _universalExtensions: dictionary with concrete implementations of
         specific TLS extensions where key is the numeric value of the extension
         ID. Contains ClientHello version of extensions or universal
         implementations
@@ -47,7 +47,7 @@ class TLSExtension(object):
         ServerHello versions.
     """
     # actual definition at the end of file, after definitions of all classes
-    _universal_extensions = {}
+    _universalExtensions = {}
     _server_extensions = {}
 
     def __init__(self, server=False):
@@ -124,8 +124,8 @@ class TLSExtension(object):
             return ext
 
         # then fallback to universal/ClientHello-specific parsers
-        if extType in self._universal_extensions:
-            ext = self._universal_extensions[extType]()
+        if extType in self._universalExtensions:
+            ext = self._universalExtensions[extType]()
             ext_parser = Parser(p.getFixBytes(ext_length))
             ext = ext.parse(ext_parser)
             return ext
@@ -912,7 +912,7 @@ class TACKExtension(TLSExtension):
 
         return self
 
-TLSExtension._universal_extensions = {
+TLSExtension._universalExtensions = {
         ExtensionType.server_name : SNIExtension,
         ExtensionType.cert_type : ClientCertTypeExtension,
         ExtensionType.srp : SRPExtension,

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -185,8 +185,8 @@ class SNIExtension(TLSExtension):
            sni_extension.host_names = names
 
 
-    @type server_names: list of L{ServerName}
-    @ivar server_names: list of all names advertised in extension.
+    @type serverNames: list of L{ServerName}
+    @ivar serverNames: list of all names advertised in extension.
         L{ServerName} is a namedtuple with two elements, the first
         element (type) defines the type of the name (encoded as int)
         while the other (name) is a bytearray that carries the value.
@@ -209,7 +209,7 @@ class SNIExtension(TLSExtension):
 
         See also: L{create} and L{parse}.
         """
-        self.server_names = None
+        self.serverNames = None
 
     def __repr__(self):
         """
@@ -217,20 +217,20 @@ class SNIExtension(TLSExtension):
 
         @rtype: str
         """
-        return "SNIExtension(server_names={0!r})".format(self.server_names)
+        return "SNIExtension(serverNames={0!r})".format(self.serverNames)
 
-    def create(self, hostname=None, host_names=None, server_names=None):
+    def create(self, hostname=None, host_names=None, serverNames=None):
         """
         Initializes an instance with provided hostname, host names or
         raw server names.
 
         Any of the parameters may be None, in that case the list inside the
-        extension won't be defined, if either host_names or server_names is
+        extension won't be defined, if either host_names or serverNames is
         an empty list, then the extension will define a list of lenght 0.
 
         If multiple parameters are specified at the same time, then the
         resulting list of names will be concatenated in order of hostname,
-        host_names and server_names last.
+        host_names and serverNames last.
 
         @type  hostname: bytearray
         @param hostname: raw UTF-8 encoding of the host name
@@ -238,28 +238,28 @@ class SNIExtension(TLSExtension):
         @type  host_names: list of bytearrays
         @param host_names: list of raw UTF-8 encoded host names
 
-        @type  server_names: list of L{ServerName}
-        @param server_names: pairs of name_type and name encoded as a namedtuple
+        @type  serverNames: list of L{ServerName}
+        @param serverNames: pairs of name_type and name encoded as a namedtuple
 
         @rtype: L{SNIExtension}
         """
-        if hostname is None and host_names is None and server_names is None:
-            self.server_names = None
+        if hostname is None and host_names is None and serverNames is None:
+            self.serverNames = None
             return self
         else:
-            self.server_names = []
+            self.serverNames = []
 
         if hostname:
-            self.server_names += [SNIExtension.ServerName(NameType.host_name,\
+            self.serverNames += [SNIExtension.ServerName(NameType.host_name,\
                     hostname)]
 
         if host_names:
-            self.server_names +=\
+            self.serverNames +=\
                     [SNIExtension.ServerName(NameType.host_name, x) for x in\
                     host_names]
 
-        if server_names:
-            self.server_names += server_names
+        if serverNames:
+            self.serverNames += serverNames
 
         return self
 
@@ -279,10 +279,10 @@ class SNIExtension(TLSExtension):
         """
         # because we can't simulate assignments to array elements we return
         # an immutable type
-        if self.server_names is None:
+        if self.serverNames is None:
             return tuple()
         else:
-            return tuple([x.name for x in self.server_names if \
+            return tuple([x.name for x in self.serverNames if \
                 x.name_type == NameType.host_name])
 
     @host_names.setter
@@ -297,10 +297,10 @@ class SNIExtension(TLSExtension):
         @param host_names: host names to replace the old server names of type 0
         """
 
-        self.server_names = \
+        self.serverNames = \
                 [SNIExtension.ServerName(NameType.host_name, x) for x in \
                     host_names] + \
-                [x for x in self.server_names if \
+                [x for x in self.serverNames if \
                     x.name_type != NameType.host_name]
 
     @host_names.deleter
@@ -308,7 +308,7 @@ class SNIExtension(TLSExtension):
         """ Remove all host names from extension, leaves other name types
         unmodified
         """
-        self.server_names = [x for x in self.server_names if \
+        self.serverNames = [x for x in self.serverNames if \
                 x.name_type != NameType.host_name]
 
     @property
@@ -317,11 +317,11 @@ class SNIExtension(TLSExtension):
 
         @rtype: bytearray
         """
-        if self.server_names is None:
+        if self.serverNames is None:
             return bytearray(0)
 
         w2 = Writer()
-        for server_name in self.server_names:
+        for server_name in self.serverNames:
             w2.add(server_name.name_type, 1)
             w2.add(len(server_name.name), 2)
             w2.bytes += server_name.name
@@ -365,13 +365,13 @@ class SNIExtension(TLSExtension):
         if p.getRemainingLength() == 0:
             return self
 
-        self.server_names = []
+        self.serverNames = []
 
         p.startLengthCheck(2)
         while not p.atLengthCheck():
             sn_type = p.get(1)
             sn_name = p.getVarBytes(2)
-            self.server_names += [SNIExtension.ServerName(sn_type, sn_name)]
+            self.serverNames += [SNIExtension.ServerName(sn_type, sn_name)]
         p.stopLengthCheck()
 
         return self

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -25,8 +25,8 @@ class TLSExtension(object):
     @ivar extType: a 2^16-1 limited integer specifying the type of the
         extension that it contains, e.g. 0 indicates server name extension
 
-    @type ext_data: bytearray
-    @ivar ext_data: a byte array containing the value of the extension as
+    @type extData: bytearray
+    @ivar extData: a byte array containing the value of the extension as
         to be written on the wire
 
     @type server_type: boolean
@@ -63,7 +63,7 @@ class TLSExtension(object):
             for parsing
         """
         self.extType = None
-        self.ext_data = bytearray(0)
+        self.extData = bytearray(0)
         self.server_type = server
 
     def create(self, extType, data):
@@ -79,7 +79,7 @@ class TLSExtension(object):
         @rtype: L{TLSExtension}
         """
         self.extType = extType
-        self.ext_data = data
+        self.extData = data
         return self
 
     def write(self):
@@ -97,8 +97,8 @@ class TLSExtension(object):
 
         w = Writer()
         w.add(self.extType, 2)
-        w.add(len(self.ext_data), 2)
-        w.addFixSeq(self.ext_data, 1)
+        w.add(len(self.extData), 2)
+        w.addFixSeq(self.extData, 1)
         return w.bytes
 
     def parse(self, p):
@@ -133,8 +133,8 @@ class TLSExtension(object):
         # finally, just save the extension data as there are extensions which
         # don't require specific handlers and indicate option by mere presence
         self.extType = extType
-        self.ext_data = p.getFixBytes(ext_length)
-        assert len(self.ext_data) == ext_length
+        self.extData = p.getFixBytes(ext_length)
+        assert len(self.extData) == ext_length
         return self
 
     def __eq__(self, that):
@@ -143,9 +143,9 @@ class TLSExtension(object):
 
         Will return False for every object that's not an extension.
         """
-        if hasattr(that, 'extType') and hasattr(that, 'ext_data'):
+        if hasattr(that, 'extType') and hasattr(that, 'extData'):
             return self.extType == that.extType and \
-                    self.ext_data == that.ext_data
+                    self.extData == that.extData
         else:
             return False
 
@@ -154,8 +154,8 @@ class TLSExtension(object):
 
         @rtype: str
         """
-        return "TLSExtension(extType={0!r}, ext_data={1!r},"\
-                " server_type={2!r})".format(self.extType, self.ext_data,
+        return "TLSExtension(extType={0!r}, extData={1!r},"\
+                " server_type={2!r})".format(self.extType, self.extData,
                                              self.server_type)
 
 class SNIExtension(TLSExtension):
@@ -197,8 +197,8 @@ class SNIExtension(TLSExtension):
     @type extType: int
     @ivar extType: numeric type of SNIExtension, i.e. 0
 
-    @type ext_data: bytearray
-    @ivar ext_data: raw representation of the extension
+    @type extData: bytearray
+    @ivar extData: raw representation of the extension
     """
 
     ServerName = namedtuple('ServerName', 'name_type name')
@@ -312,7 +312,7 @@ class SNIExtension(TLSExtension):
                 x.name_type != NameType.host_name]
 
     @property
-    def ext_data(self):
+    def extData(self):
         """ raw encoding of extension data, without type and length header
 
         @rtype: bytearray
@@ -340,7 +340,7 @@ class SNIExtension(TLSExtension):
             on the wire, including the type, length and extension data
         """
 
-        raw_data = self.ext_data
+        raw_data = self.extData
 
         w = Writer()
         w.add(self.extType, 2)
@@ -384,8 +384,8 @@ class ClientCertTypeExtension(TLSExtension):
     @type extType: int
     @ivar extType: numeric type of Certificate Type extension, i.e. 9
 
-    @type ext_data: bytearray
-    @ivar ext_data: raw representation of the extension data
+    @type extData: bytearray
+    @ivar extData: raw representation of the extension data
 
     @type cert_types: list of int
     @ivar cert_types: list of certificate type identifiers (each one byte long)
@@ -419,7 +419,7 @@ class ClientCertTypeExtension(TLSExtension):
         return ExtensionType.cert_type
 
     @property
-    def ext_data(self):
+    def extData(self):
         """
         Return the raw encoding of this extension
 
@@ -474,8 +474,8 @@ class ServerCertTypeExtension(TLSExtension):
     @type extType: int
     @ivar extType: byneruc ttoe if Certificate Type extension, i.e. 9
 
-    @type ext_data: bytearray
-    @ivar ext_data: raw representation of the extension data
+    @type extData: bytearray
+    @ivar extData: raw representation of the extension data
 
     @type cert_type: int
     @ivar cert_type: the certificate type selected by server
@@ -507,7 +507,7 @@ class ServerCertTypeExtension(TLSExtension):
         return ExtensionType.cert_type
 
     @property
-    def ext_data(self):
+    def extData(self):
         """
         Return the raw encoding of the extension data
 
@@ -550,8 +550,8 @@ class SRPExtension(TLSExtension):
     @type extType: int
     @ivar extType: numeric type of SRPExtension, i.e. 12
 
-    @type ext_data: bytearray
-    @ivar ext_data: raw representation of extension data
+    @type extData: bytearray
+    @ivar extData: raw representation of extension data
 
     @type identity: bytearray
     @ivar identity: UTF-8 encoding of user name
@@ -585,7 +585,7 @@ class SRPExtension(TLSExtension):
         return ExtensionType.srp
 
     @property
-    def ext_data(self):
+    def extData(self):
         """
         Return raw data encoding of the extension
 
@@ -646,8 +646,8 @@ class NPNExtension(TLSExtension):
     @type extType: int
     @ivar extType: numeric type of NPNExtension, i.e. 13172
 
-    @type ext_data: bytearray
-    @ivar ext_data: raw representation of extension data
+    @type extData: bytearray
+    @ivar extData: raw representation of extension data
     """
 
     def __init__(self):
@@ -676,7 +676,7 @@ class NPNExtension(TLSExtension):
         return ExtensionType.supports_npn
 
     @property
-    def ext_data(self):
+    def extData(self):
         """ Return the raw data encoding of the extension
 
         @rtype: bytearray
@@ -865,7 +865,7 @@ class TACKExtension(TLSExtension):
         return ExtensionType.tack
 
     @property
-    def ext_data(self):
+    def extData(self):
         """
         Return the raw data encoding of the extension
 

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -400,8 +400,8 @@ class ClientHello(HandshakeMsg):
         if sni_ext is None:
             return bytearray(0)
         else:
-            if len(sni_ext.host_names) > 0:
-                return sni_ext.host_names[0]
+            if len(sni_ext.hostNames) > 0:
+                return sni_ext.hostNames[0]
             else:
                 return bytearray(0)
 
@@ -418,9 +418,9 @@ class ClientHello(HandshakeMsg):
             sni_ext = SNIExtension().create(hostname)
             self.addExtension(sni_ext)
         else:
-            names = list(sni_ext.host_names)
+            names = list(sni_ext.hostNames)
             names[0] = hostname
-            sni_ext.host_names = names
+            sni_ext.hostNames = names
 
     def create(self, version, random, session_id, cipher_suites,
                certificate_types=None, srpUsername=None,

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -259,7 +259,7 @@ class ClientHello(HandshakeMsg):
             # depends on a default value of this property
             return [CertificateType.x509]
         else:
-            return cert_type.cert_types
+            return cert_type.certTypes
 
     @certificate_types.setter
     def certificate_types(self, val):
@@ -278,7 +278,7 @@ class ClientHello(HandshakeMsg):
             ext = ClientCertTypeExtension().create(val)
             self.addExtension(ext)
         else:
-            cert_type.cert_types = val
+            cert_type.certTypes = val
 
     @property
     def srp_username(self):

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -108,7 +108,7 @@ class Alert(object):
         return w.bytes
 
     @property
-    def level_name(self):
+    def levelName(self):
         matching = [x[0] for x in AlertLevel.__dict__.items()
                 if x[1] == self.level]
         if len(matching) == 0:
@@ -126,7 +126,7 @@ class Alert(object):
             return str(matching[0])
 
     def __str__(self):
-        return "Alert, level:{0}, description:{1}".format(self.level_name,
+        return "Alert, level:{0}, description:{1}".format(self.levelName,
                 self.description_name)
 
     def __repr__(self):

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -117,7 +117,7 @@ class Alert(object):
             return str(matching[0])
 
     @property
-    def description_name(self):
+    def descriptionName(self):
         matching = [x[0] for x in AlertDescription.__dict__.items()
                 if x[1] == self.description]
         if len(matching) == 0:
@@ -127,7 +127,7 @@ class Alert(object):
 
     def __str__(self):
         return "Alert, level:{0}, description:{1}".format(self.levelName,
-                self.description_name)
+                self.descriptionName)
 
     def __repr__(self):
         return "Alert(level={0}, description={1})".format(self.level,

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -637,7 +637,7 @@ class ServerHello(HandshakeMsg):
             if ext is None or not tackpyLoaded:
                 return None
             else:
-                self._tack_ext = TackExtension(ext.ext_data)
+                self._tack_ext = TackExtension(ext.extData)
         return self._tack_ext
 
     @tackExt.setter

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -214,7 +214,7 @@ class ClientHello(HandshakeMsg):
                 self.ssl2, self.client_version, self.random, self.session_id,
                 self.cipher_suites, self.compression_methods, self.extensions)
 
-    def getExtension(self, ext_type):
+    def getExtension(self, extType):
         """
         Returns extension of given type if present, None otherwise
 
@@ -225,7 +225,7 @@ class ClientHello(HandshakeMsg):
         if self.extensions is None:
             return None
 
-        exts = [x for x in self.extensions if x.ext_type == ext_type]
+        exts = [ext for ext in self.extensions if ext.extType == extType]
         if len(exts) > 1:
             raise TLSInternalError(
                     "Multiple extensions of the same type present")
@@ -345,8 +345,8 @@ class ClientHello(HandshakeMsg):
             if self.extensions is None:
                 return
             # remove all extensions of this type without changing reference
-            self.extensions[:] = [x for x in self.extensions if
-                    x.ext_type != ExtensionType.tack]
+            self.extensions[:] = [ext for ext in self.extensions if
+                                  ext.extType != ExtensionType.tack]
 
     @property
     def supports_npn(self):
@@ -385,8 +385,8 @@ class ClientHello(HandshakeMsg):
             if self.extensions is None:
                 return
             #remove all extension of this type without changing reference
-            self.extensions[:] = [x for x in self.extensions if
-                    x.ext_type != ExtensionType.supports_npn]
+            self.extensions[:] = [ext for ext in self.extensions if
+                                  ext.extType != ExtensionType.supports_npn]
 
     @property
     def server_name(self):
@@ -598,7 +598,7 @@ class ServerHello(HandshakeMsg):
                 self.cipher_suite, self.compression_method, self._tack_ext,
                 self.extensions)
 
-    def getExtension(self, ext_type):
+    def getExtension(self, extType):
         """Return extension of a given type, None if extension of given type
         is not present
 
@@ -608,7 +608,7 @@ class ServerHello(HandshakeMsg):
         if self.extensions is None:
             return None
 
-        exts = [x for x in self.extensions if x.ext_type == ext_type]
+        exts = [ext for ext in self.extensions if ext.extType == extType]
         if len(exts) > 1:
             raise TLSInternalError(
                     "Multiple extensions of the same type present")

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -49,7 +49,7 @@ class RecordHeader3(object):
         return self
 
     @property
-    def type_name(self):
+    def typeName(self):
         matching = [x[0] for x in ContentType.__dict__.items()
                 if x[1] == self.type]
         if len(matching) == 0:
@@ -60,7 +60,7 @@ class RecordHeader3(object):
     def __str__(self):
         return "SSLv3 record,version({0[0]}.{0[1]}),"\
                 "content type({1}),length({2})".format(self.version,
-                        self.type_name, self.length)
+                        self.typeName, self.length)
 
     def __repr__(self):
         return "RecordHeader3(type={0}, version=({1[0]}.{1[1]}), length={2})".\

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -20,14 +20,14 @@ class TestTLSExtension(unittest.TestCase):
         tls_extension = TLSExtension()
 
         assert(tls_extension)
-        self.assertIsNone(tls_extension.ext_type)
+        self.assertIsNone(tls_extension.extType)
         self.assertEqual(bytearray(0), tls_extension.ext_data)
 
     def test_create(self):
         tls_extension = TLSExtension().create(1, bytearray(b'\x01\x00'))
 
         assert tls_extension
-        self.assertEqual(1, tls_extension.ext_type)
+        self.assertEqual(1, tls_extension.extType)
         self.assertEqual(bytearray(b'\x01\x00'), tls_extension.ext_data)
 
     def test_write(self):
@@ -54,7 +54,7 @@ class TestTLSExtension(unittest.TestCase):
             ))
         tls_extension = TLSExtension().parse(p)
 
-        self.assertEqual(66, tls_extension.ext_type)
+        self.assertEqual(66, tls_extension.extType)
         self.assertEqual(bytearray(b'\xff'), tls_extension.ext_data)
 
     def test_parse_with_length_long_by_one(self):
@@ -107,7 +107,7 @@ class TestTLSExtension(unittest.TestCase):
     def test_equality_with_nearly_good_object(self):
         class TestClass(object):
             def __init__(self):
-                self.ext_type = 0
+                self.extType = 0
 
         a = TLSExtension().create(0, bytearray(b'\x00\x00'))
         b = TestClass()
@@ -131,7 +131,7 @@ class TestTLSExtension(unittest.TestCase):
         ext = TLSExtension()
         ext = ext.create(0, bytearray(b'\x00\x00'))
 
-        self.assertEqual("TLSExtension(ext_type=0, "\
+        self.assertEqual("TLSExtension(extType=0, "\
                 "ext_data=bytearray(b'\\x00\\x00'), server_type=False)",
                 repr(ext))
 
@@ -142,7 +142,7 @@ class TestSNIExtension(unittest.TestCase):
         self.assertEqual(None, server_name.server_names)
         self.assertEqual(tuple(), server_name.host_names)
         # properties inherited from TLSExtension:
-        self.assertEqual(0, server_name.ext_type)
+        self.assertEqual(0, server_name.extType)
         self.assertEqual(bytearray(0), server_name.ext_data)
 
     def test_create(self):
@@ -484,7 +484,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
     def test___init___(self):
         cert_type = ClientCertTypeExtension()
 
-        self.assertEqual(9, cert_type.ext_type)
+        self.assertEqual(9, cert_type.extType)
         self.assertEqual(bytearray(0), cert_type.ext_data)
         self.assertEqual(None, cert_type.cert_types)
 
@@ -492,7 +492,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
         cert_type = ClientCertTypeExtension()
         cert_type = cert_type.create()
 
-        self.assertEqual(9, cert_type.ext_type)
+        self.assertEqual(9, cert_type.extType)
         self.assertEqual(bytearray(0), cert_type.ext_data)
         self.assertEqual(None, cert_type.cert_types)
 
@@ -527,7 +527,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
 
         cert_type = cert_type.parse(p)
 
-        self.assertEqual(9, cert_type.ext_type)
+        self.assertEqual(9, cert_type.extType)
         self.assertEqual([], cert_type.cert_types)
 
     def test_parse_with_list(self):
@@ -558,14 +558,14 @@ class TestServerCertTypeExtension(unittest.TestCase):
     def test___init__(self):
         cert_type = ServerCertTypeExtension()
 
-        self.assertEqual(9, cert_type.ext_type)
+        self.assertEqual(9, cert_type.extType)
         self.assertEqual(bytearray(0), cert_type.ext_data)
         self.assertEqual(None, cert_type.cert_type)
 
     def test_create(self):
         cert_type = ServerCertTypeExtension().create(0)
 
-        self.assertEqual(9, cert_type.ext_type)
+        self.assertEqual(9, cert_type.extType)
         self.assertEqual(bytearray(b'\x00'), cert_type.ext_data)
         self.assertEqual(0, cert_type.cert_type)
 
@@ -614,7 +614,7 @@ class TestSRPExtension(unittest.TestCase):
         srp_extension = SRPExtension()
 
         self.assertEqual(None, srp_extension.identity)
-        self.assertEqual(12, srp_extension.ext_type)
+        self.assertEqual(12, srp_extension.extType)
         self.assertEqual(bytearray(0), srp_extension.ext_data)
 
     def test_create(self):
@@ -622,7 +622,7 @@ class TestSRPExtension(unittest.TestCase):
         srp_extension = srp_extension.create()
 
         self.assertEqual(None, srp_extension.identity)
-        self.assertEqual(12, srp_extension.ext_type)
+        self.assertEqual(12, srp_extension.extType)
         self.assertEqual(bytearray(0), srp_extension.ext_data)
 
     def test_create_with_name(self):
@@ -690,7 +690,7 @@ class TestNPNExtension(unittest.TestCase):
         npn_extension = NPNExtension()
 
         self.assertEqual(None, npn_extension.protocols)
-        self.assertEqual(13172, npn_extension.ext_type)
+        self.assertEqual(13172, npn_extension.extType)
         self.assertEqual(bytearray(0), npn_extension.ext_data)
 
     def test_create(self):
@@ -698,7 +698,7 @@ class TestNPNExtension(unittest.TestCase):
         npn_extension = npn_extension.create()
 
         self.assertEqual(None, npn_extension.protocols)
-        self.assertEqual(13172, npn_extension.ext_type)
+        self.assertEqual(13172, npn_extension.extType)
         self.assertEqual(bytearray(0), npn_extension.ext_data)
 
     def test_create_with_list_of_protocols(self):
@@ -797,7 +797,7 @@ class TestTACKExtension(unittest.TestCase):
 
         self.assertEqual([], tack_ext.tacks)
         self.assertEqual(0, tack_ext.activation_flags)
-        self.assertEqual(62208, tack_ext.ext_type)
+        self.assertEqual(62208, tack_ext.extType)
         self.assertEqual(bytearray(b'\x00\x00\x00'), tack_ext.ext_data)
 
     def test_create(self):

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -21,14 +21,14 @@ class TestTLSExtension(unittest.TestCase):
 
         assert(tls_extension)
         self.assertIsNone(tls_extension.extType)
-        self.assertEqual(bytearray(0), tls_extension.ext_data)
+        self.assertEqual(bytearray(0), tls_extension.extData)
 
     def test_create(self):
         tls_extension = TLSExtension().create(1, bytearray(b'\x01\x00'))
 
         assert tls_extension
         self.assertEqual(1, tls_extension.extType)
-        self.assertEqual(bytearray(b'\x01\x00'), tls_extension.ext_data)
+        self.assertEqual(bytearray(b'\x01\x00'), tls_extension.extData)
 
     def test_write(self):
         tls_extension = TLSExtension()
@@ -55,7 +55,7 @@ class TestTLSExtension(unittest.TestCase):
         tls_extension = TLSExtension().parse(p)
 
         self.assertEqual(66, tls_extension.extType)
-        self.assertEqual(bytearray(b'\xff'), tls_extension.ext_data)
+        self.assertEqual(bytearray(b'\xff'), tls_extension.extData)
 
     def test_parse_with_length_long_by_one(self):
         p = Parser(bytearray(
@@ -132,7 +132,7 @@ class TestTLSExtension(unittest.TestCase):
         ext = ext.create(0, bytearray(b'\x00\x00'))
 
         self.assertEqual("TLSExtension(extType=0, "\
-                "ext_data=bytearray(b'\\x00\\x00'), server_type=False)",
+                "extData=bytearray(b'\\x00\\x00'), server_type=False)",
                 repr(ext))
 
 class TestSNIExtension(unittest.TestCase):
@@ -143,7 +143,7 @@ class TestSNIExtension(unittest.TestCase):
         self.assertEqual(tuple(), server_name.host_names)
         # properties inherited from TLSExtension:
         self.assertEqual(0, server_name.extType)
-        self.assertEqual(bytearray(0), server_name.ext_data)
+        self.assertEqual(bytearray(0), server_name.extData)
 
     def test_create(self):
         server_name = SNIExtension()
@@ -241,7 +241,7 @@ class TestSNIExtension(unittest.TestCase):
             b'\x00\x0b' +   # length of element - 11 bytes
             # UTF-8 encoding of example.com
             b'\x65\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d'
-            ), server_name.ext_data)
+            ), server_name.extData)
 
         self.assertEqual(bytearray(
             b'\x00\x00' +   # type of extension - SNI (0)
@@ -269,7 +269,7 @@ class TestSNIExtension(unittest.TestCase):
             b'\x00\x0b' +   # length of elemnet - 11 bytes
             # utf-8 encoding of example.org
             b'\x65\x78\x61\x6d\x70\x6c\x65\x2e\x6f\x72\x67'
-            ), server_name.ext_data)
+            ), server_name.extData)
 
         self.assertEqual(bytearray(
             b'\x00\x00' +   # type of extension - SNI (0)
@@ -299,7 +299,7 @@ class TestSNIExtension(unittest.TestCase):
 
         self.assertEqual(bytearray(
             b'\x00\x00'    # length of array - 0 bytes
-            ), server_name.ext_data)
+            ), server_name.extData)
 
         self.assertEqual(bytearray(
             b'\x00\x00' +  # type of extension - SNI 0
@@ -485,7 +485,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
         cert_type = ClientCertTypeExtension()
 
         self.assertEqual(9, cert_type.extType)
-        self.assertEqual(bytearray(0), cert_type.ext_data)
+        self.assertEqual(bytearray(0), cert_type.extData)
         self.assertEqual(None, cert_type.cert_types)
 
     def test_create(self):
@@ -493,21 +493,21 @@ class TestClientCertTypeExtension(unittest.TestCase):
         cert_type = cert_type.create()
 
         self.assertEqual(9, cert_type.extType)
-        self.assertEqual(bytearray(0), cert_type.ext_data)
+        self.assertEqual(bytearray(0), cert_type.extData)
         self.assertEqual(None, cert_type.cert_types)
 
     def test_create_with_empty_list(self):
         cert_type = ClientCertTypeExtension()
         cert_type = cert_type.create([])
 
-        self.assertEqual(bytearray(b'\x00'), cert_type.ext_data)
+        self.assertEqual(bytearray(b'\x00'), cert_type.extData)
         self.assertEqual([], cert_type.cert_types)
 
     def test_create_with_list(self):
         cert_type = ClientCertTypeExtension()
         cert_type = cert_type.create([0])
 
-        self.assertEqual(bytearray(b'\x01\x00'), cert_type.ext_data)
+        self.assertEqual(bytearray(b'\x01\x00'), cert_type.extData)
         self.assertEqual([0], cert_type.cert_types)
 
     def test_write(self):
@@ -559,14 +559,14 @@ class TestServerCertTypeExtension(unittest.TestCase):
         cert_type = ServerCertTypeExtension()
 
         self.assertEqual(9, cert_type.extType)
-        self.assertEqual(bytearray(0), cert_type.ext_data)
+        self.assertEqual(bytearray(0), cert_type.extData)
         self.assertEqual(None, cert_type.cert_type)
 
     def test_create(self):
         cert_type = ServerCertTypeExtension().create(0)
 
         self.assertEqual(9, cert_type.extType)
-        self.assertEqual(bytearray(b'\x00'), cert_type.ext_data)
+        self.assertEqual(bytearray(b'\x00'), cert_type.extData)
         self.assertEqual(0, cert_type.cert_type)
 
     def test_parse(self):
@@ -615,7 +615,7 @@ class TestSRPExtension(unittest.TestCase):
 
         self.assertEqual(None, srp_extension.identity)
         self.assertEqual(12, srp_extension.extType)
-        self.assertEqual(bytearray(0), srp_extension.ext_data)
+        self.assertEqual(bytearray(0), srp_extension.extData)
 
     def test_create(self):
         srp_extension = SRPExtension()
@@ -623,7 +623,7 @@ class TestSRPExtension(unittest.TestCase):
 
         self.assertEqual(None, srp_extension.identity)
         self.assertEqual(12, srp_extension.extType)
-        self.assertEqual(bytearray(0), srp_extension.ext_data)
+        self.assertEqual(bytearray(0), srp_extension.extData)
 
     def test_create_with_name(self):
         srp_extension = SRPExtension()
@@ -632,7 +632,7 @@ class TestSRPExtension(unittest.TestCase):
         self.assertEqual(bytearray(b'username'), srp_extension.identity)
         self.assertEqual(bytearray(
             b'\x08' + # length of string - 8 bytes
-            b'username'), srp_extension.ext_data)
+            b'username'), srp_extension.extData)
 
     def test_create_with_too_long_name(self):
         srp_extension = SRPExtension()
@@ -691,7 +691,7 @@ class TestNPNExtension(unittest.TestCase):
 
         self.assertEqual(None, npn_extension.protocols)
         self.assertEqual(13172, npn_extension.extType)
-        self.assertEqual(bytearray(0), npn_extension.ext_data)
+        self.assertEqual(bytearray(0), npn_extension.extData)
 
     def test_create(self):
         npn_extension = NPNExtension()
@@ -699,7 +699,7 @@ class TestNPNExtension(unittest.TestCase):
 
         self.assertEqual(None, npn_extension.protocols)
         self.assertEqual(13172, npn_extension.extType)
-        self.assertEqual(bytearray(0), npn_extension.ext_data)
+        self.assertEqual(bytearray(0), npn_extension.extData)
 
     def test_create_with_list_of_protocols(self):
         npn_extension = NPNExtension()
@@ -717,7 +717,7 @@ class TestNPNExtension(unittest.TestCase):
             b'\x06' +   # length of name of protocol
             # utf-8 encoding of "http/1.1"
             b'\x73\x70\x64\x79\x2f\x33'
-            ), npn_extension.ext_data)
+            ), npn_extension.extData)
 
     def test_write(self):
         npn_extension = NPNExtension().create()
@@ -751,7 +751,7 @@ class TestNPNExtension(unittest.TestCase):
 
         npn_extension = npn_extension.parse(p)
 
-        self.assertEqual(bytearray(0), npn_extension.ext_data)
+        self.assertEqual(bytearray(0), npn_extension.extData)
         self.assertEqual([], npn_extension.protocols)
 
     def test_parse_with_procotol(self):
@@ -798,7 +798,7 @@ class TestTACKExtension(unittest.TestCase):
         self.assertEqual([], tack_ext.tacks)
         self.assertEqual(0, tack_ext.activation_flags)
         self.assertEqual(62208, tack_ext.extType)
-        self.assertEqual(bytearray(b'\x00\x00\x00'), tack_ext.ext_data)
+        self.assertEqual(bytearray(b'\x00\x00\x00'), tack_ext.extData)
 
     def test_create(self):
         tack_ext = TACKExtension().create([], 1)
@@ -926,7 +926,7 @@ class TestTACKExtension(unittest.TestCase):
 
         self.assertFalse(a == b)
 
-    def test_ext_data(self):
+    def test_extData(self):
         tack = TACKExtension.TACK().create(
                 bytearray(b'\x01'*64),
                 2,
@@ -946,7 +946,7 @@ class TestTACKExtension(unittest.TestCase):
             b'\x05'*32 +            # target_hash
             b'\x06'*64 +            # signature
             b'\x01'                 # activation flag
-            ), tack_ext.ext_data)
+            ), tack_ext.extData)
 
     def test_parse(self):
         p = Parser(bytearray(3))

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -90,7 +90,7 @@ class TestTLSExtension(unittest.TestCase):
         ext = TLSExtension(server=True).parse(p)
 
         self.assertIsInstance(ext, SNIExtension)
-        self.assertEqual(ext.server_names, None)
+        self.assertIsNone(ext.serverNames)
 
     def test_equality(self):
         a = TLSExtension().create(0, bytearray(0))
@@ -100,7 +100,7 @@ class TestTLSExtension(unittest.TestCase):
 
     def test_equality_with_empty_array_in_sni_extension(self):
         a = TLSExtension().create(0, bytearray(b'\x00\x00'))
-        b = SNIExtension().create(server_names=[])
+        b = SNIExtension().create(serverNames=[])
 
         self.assertTrue(a == b)
 
@@ -139,7 +139,7 @@ class TestSNIExtension(unittest.TestCase):
     def test___init__(self):
         server_name = SNIExtension()
 
-        self.assertEqual(None, server_name.server_names)
+        self.assertIsNone(server_name.serverNames)
         self.assertEqual(tuple(), server_name.host_names)
         # properties inherited from TLSExtension:
         self.assertEqual(0, server_name.extType)
@@ -149,7 +149,7 @@ class TestSNIExtension(unittest.TestCase):
         server_name = SNIExtension()
         server_name = server_name.create()
 
-        self.assertEqual(None, server_name.server_names)
+        self.assertIsNone(server_name.serverNames)
         self.assertEqual(tuple(), server_name.host_names)
 
     def test_create_with_hostname(self):
@@ -160,7 +160,7 @@ class TestSNIExtension(unittest.TestCase):
         self.assertEqual([SNIExtension.ServerName(
             NameType.host_name,
             bytearray(b'example.com')
-            )], server_name.server_names)
+            )], server_name.serverNames)
 
     def test_create_with_host_names(self):
         server_name = SNIExtension()
@@ -178,11 +178,11 @@ class TestSNIExtension(unittest.TestCase):
             SNIExtension.ServerName(
                 NameType.host_name,
                 bytearray(b'www.example.com'))],
-            server_name.server_names)
+            server_name.serverNames)
 
-    def test_create_with_server_names(self):
+    def test_create_with_serverNames(self):
         server_name = SNIExtension()
-        server_name = server_name.create(server_names=[
+        server_name = server_name.create(serverNames=[
             SNIExtension.ServerName(1, bytearray(b'example.com')),
             SNIExtension.ServerName(4, bytearray(b'www.example.com')),
             SNIExtension.ServerName(0, bytearray(b'example.net'))])
@@ -195,11 +195,11 @@ class TestSNIExtension(unittest.TestCase):
                 4, bytearray(b'www.example.com')),
             SNIExtension.ServerName(
                 0, bytearray(b'example.net'))],
-            server_name.server_names)
+            server_name.serverNames)
 
     def test_host_names(self):
         server_name = SNIExtension()
-        server_name = server_name.create(server_names=[
+        server_name = server_name.create(serverNames=[
             SNIExtension.ServerName(0, bytearray(b'example.net')),
             SNIExtension.ServerName(1, bytearray(b'example.com')),
             SNIExtension.ServerName(4, bytearray(b'www.example.com'))
@@ -213,11 +213,11 @@ class TestSNIExtension(unittest.TestCase):
             SNIExtension.ServerName(0, bytearray(b'example.com')),
             SNIExtension.ServerName(1, bytearray(b'example.com')),
             SNIExtension.ServerName(4, bytearray(b'www.example.com'))],
-            server_name.server_names)
+            server_name.serverNames)
 
     def test_host_names_delete(self):
         server_name = SNIExtension()
-        server_name = server_name.create(server_names=[
+        server_name = server_name.create(serverNames=[
             SNIExtension.ServerName(0, bytearray(b'example.net')),
             SNIExtension.ServerName(1, bytearray(b'example.com')),
             SNIExtension.ServerName(4, bytearray(b'www.example.com'))
@@ -229,7 +229,7 @@ class TestSNIExtension(unittest.TestCase):
         self.assertEqual([
             SNIExtension.ServerName(1, bytearray(b'example.com')),
             SNIExtension.ServerName(4, bytearray(b'www.example.com'))],
-            server_name.server_names)
+            server_name.serverNames)
 
     def test_write(self):
         server_name = SNIExtension()
@@ -295,7 +295,7 @@ class TestSNIExtension(unittest.TestCase):
 
     def test_write_of_empty_list_of_names(self):
         server_name = SNIExtension()
-        server_name = server_name.create(server_names=[])
+        server_name = server_name.create(serverNames=[])
 
         self.assertEqual(bytearray(
             b'\x00\x00'    # length of array - 0 bytes
@@ -322,7 +322,7 @@ class TestSNIExtension(unittest.TestCase):
 
         server_name = server_name.parse(p)
 
-        self.assertIsNone(server_name.server_names)
+        self.assertIsNone(server_name.serverNames)
 
     def test_parse_null_length_array(self):
         server_name = SNIExtension()
@@ -331,7 +331,7 @@ class TestSNIExtension(unittest.TestCase):
 
         server_name = server_name.parse(p)
 
-        self.assertEqual([], server_name.server_names)
+        self.assertEqual([], server_name.serverNames)
 
     def test_parse_with_host_name(self):
         server_name = SNIExtension()
@@ -374,7 +374,7 @@ class TestSNIExtension(unittest.TestCase):
         self.assertEqual([
             SN(10, bytearray(b'example.org')),
             SN(0, bytearray(b'example.com'))
-            ], server_name.server_names)
+            ], server_name.serverNames)
 
     def test_parse_with_array_length_long_by_one(self):
         server_name = SNIExtension()
@@ -471,11 +471,11 @@ class TestSNIExtension(unittest.TestCase):
     def test___repr__(self):
         server_name = SNIExtension()
         server_name = server_name.create(
-                server_names=[
+                serverNames=[
                     SNIExtension.ServerName(0, bytearray(b'example.com')),
                     SNIExtension.ServerName(1, bytearray(b'\x04\x01'))])
 
-        self.assertEqual("SNIExtension(server_names=["\
+        self.assertEqual("SNIExtension(serverNames=["\
                 "ServerName(name_type=0, name=bytearray(b'example.com')), "\
                 "ServerName(name_type=1, name=bytearray(b'\\x04\\x01'))])",
                 repr(server_name))

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -486,7 +486,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
 
         self.assertEqual(9, cert_type.extType)
         self.assertEqual(bytearray(0), cert_type.extData)
-        self.assertEqual(None, cert_type.cert_types)
+        self.assertIsNone(cert_type.certTypes)
 
     def test_create(self):
         cert_type = ClientCertTypeExtension()
@@ -494,21 +494,21 @@ class TestClientCertTypeExtension(unittest.TestCase):
 
         self.assertEqual(9, cert_type.extType)
         self.assertEqual(bytearray(0), cert_type.extData)
-        self.assertEqual(None, cert_type.cert_types)
+        self.assertIsNone(cert_type.certTypes)
 
     def test_create_with_empty_list(self):
         cert_type = ClientCertTypeExtension()
         cert_type = cert_type.create([])
 
         self.assertEqual(bytearray(b'\x00'), cert_type.extData)
-        self.assertEqual([], cert_type.cert_types)
+        self.assertEqual([], cert_type.certTypes)
 
     def test_create_with_list(self):
         cert_type = ClientCertTypeExtension()
         cert_type = cert_type.create([0])
 
         self.assertEqual(bytearray(b'\x01\x00'), cert_type.extData)
-        self.assertEqual([0], cert_type.cert_types)
+        self.assertEqual([0], cert_type.certTypes)
 
     def test_write(self):
         cert_type = ClientCertTypeExtension()
@@ -528,7 +528,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
         cert_type = cert_type.parse(p)
 
         self.assertEqual(9, cert_type.extType)
-        self.assertEqual([], cert_type.cert_types)
+        self.assertEqual([], cert_type.certTypes)
 
     def test_parse_with_list(self):
         cert_type = ClientCertTypeExtension()
@@ -537,7 +537,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
 
         cert_type = cert_type.parse(p)
 
-        self.assertEqual([1, 0], cert_type.cert_types)
+        self.assertEqual([1, 0], cert_type.certTypes)
 
     def test_parse_with_length_long_by_one(self):
         cert_type = ClientCertTypeExtension()
@@ -551,7 +551,7 @@ class TestClientCertTypeExtension(unittest.TestCase):
         cert_type = ClientCertTypeExtension()
         cert_type = cert_type.create([0, 1])
 
-        self.assertEqual("ClientCertTypeExtension(cert_types=[0, 1])",
+        self.assertEqual("ClientCertTypeExtension(certTypes=[0, 1])",
                 repr(cert_type))
 
 class TestServerCertTypeExtension(unittest.TestCase):

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -79,7 +79,7 @@ class TestTLSExtension(unittest.TestCase):
 
         tls_extension = TLSExtension().parse(p)
 
-        self.assertEqual(bytearray(b'example.com'), tls_extension.host_names[0])
+        self.assertEqual(bytearray(b'example.com'), tls_extension.hostNames[0])
 
     def test_parse_with_SNI_server_side(self):
         p = Parser(bytearray(
@@ -140,7 +140,7 @@ class TestSNIExtension(unittest.TestCase):
         server_name = SNIExtension()
 
         self.assertIsNone(server_name.serverNames)
-        self.assertEqual(tuple(), server_name.host_names)
+        self.assertEqual(tuple(), server_name.hostNames)
         # properties inherited from TLSExtension:
         self.assertEqual(0, server_name.extType)
         self.assertEqual(bytearray(0), server_name.extData)
@@ -150,27 +150,27 @@ class TestSNIExtension(unittest.TestCase):
         server_name = server_name.create()
 
         self.assertIsNone(server_name.serverNames)
-        self.assertEqual(tuple(), server_name.host_names)
+        self.assertEqual(tuple(), server_name.hostNames)
 
     def test_create_with_hostname(self):
         server_name = SNIExtension()
         server_name = server_name.create(bytearray(b'example.com'))
 
-        self.assertEqual((bytearray(b'example.com'),), server_name.host_names)
+        self.assertEqual((bytearray(b'example.com'),), server_name.hostNames)
         self.assertEqual([SNIExtension.ServerName(
             NameType.host_name,
             bytearray(b'example.com')
             )], server_name.serverNames)
 
-    def test_create_with_host_names(self):
+    def test_create_with_hostNames(self):
         server_name = SNIExtension()
-        server_name = server_name.create(host_names=[bytearray(b'example.com'),
+        server_name = server_name.create(hostNames=[bytearray(b'example.com'),
             bytearray(b'www.example.com')])
 
         self.assertEqual((
             bytearray(b'example.com'),
             bytearray(b'www.example.com')
-            ), server_name.host_names)
+            ), server_name.hostNames)
         self.assertEqual([
             SNIExtension.ServerName(
                 NameType.host_name,
@@ -187,7 +187,7 @@ class TestSNIExtension(unittest.TestCase):
             SNIExtension.ServerName(4, bytearray(b'www.example.com')),
             SNIExtension.ServerName(0, bytearray(b'example.net'))])
 
-        self.assertEqual((bytearray(b'example.net'),), server_name.host_names)
+        self.assertEqual((bytearray(b'example.net'),), server_name.hostNames)
         self.assertEqual([
             SNIExtension.ServerName(
                 1, bytearray(b'example.com')),
@@ -197,7 +197,7 @@ class TestSNIExtension(unittest.TestCase):
                 0, bytearray(b'example.net'))],
             server_name.serverNames)
 
-    def test_host_names(self):
+    def test_hostNames(self):
         server_name = SNIExtension()
         server_name = server_name.create(serverNames=[
             SNIExtension.ServerName(0, bytearray(b'example.net')),
@@ -205,17 +205,17 @@ class TestSNIExtension(unittest.TestCase):
             SNIExtension.ServerName(4, bytearray(b'www.example.com'))
             ])
 
-        server_name.host_names = \
+        server_name.hostNames = \
                 [bytearray(b'example.com')]
 
-        self.assertEqual((bytearray(b'example.com'),), server_name.host_names)
+        self.assertEqual((bytearray(b'example.com'),), server_name.hostNames)
         self.assertEqual([
             SNIExtension.ServerName(0, bytearray(b'example.com')),
             SNIExtension.ServerName(1, bytearray(b'example.com')),
             SNIExtension.ServerName(4, bytearray(b'www.example.com'))],
             server_name.serverNames)
 
-    def test_host_names_delete(self):
+    def test_hostNames_delete(self):
         server_name = SNIExtension()
         server_name = server_name.create(serverNames=[
             SNIExtension.ServerName(0, bytearray(b'example.net')),
@@ -223,9 +223,9 @@ class TestSNIExtension(unittest.TestCase):
             SNIExtension.ServerName(4, bytearray(b'www.example.com'))
             ])
 
-        del server_name.host_names
+        del server_name.hostNames
 
-        self.assertEqual(tuple(), server_name.host_names)
+        self.assertEqual(tuple(), server_name.hostNames)
         self.assertEqual([
             SNIExtension.ServerName(1, bytearray(b'example.com')),
             SNIExtension.ServerName(4, bytearray(b'www.example.com'))],
@@ -255,7 +255,7 @@ class TestSNIExtension(unittest.TestCase):
 
     def test_write_with_multiple_hostnames(self):
         server_name = SNIExtension()
-        server_name = server_name.create(host_names=[
+        server_name = server_name.create(hostNames=[
             bytearray(b'example.com'),
             bytearray(b'example.org')])
 
@@ -345,11 +345,11 @@ class TestSNIExtension(unittest.TestCase):
 
         server_name = server_name.parse(p)
 
-        self.assertEqual(bytearray(b'example.com'), server_name.host_names[0])
+        self.assertEqual(bytearray(b'example.com'), server_name.hostNames[0])
         self.assertEqual(tuple([bytearray(b'example.com')]),
-                server_name.host_names)
+                server_name.hostNames)
 
-    def test_parse_with_multiple_host_names(self):
+    def test_parse_with_multiple_hostNames(self):
         server_name = SNIExtension()
 
         p = Parser(bytearray(
@@ -365,9 +365,9 @@ class TestSNIExtension(unittest.TestCase):
 
         server_name = server_name.parse(p)
 
-        self.assertEqual(bytearray(b'example.com'), server_name.host_names[0])
+        self.assertEqual(bytearray(b'example.com'), server_name.hostNames[0])
         self.assertEqual(tuple([bytearray(b'example.com')]),
-                server_name.host_names)
+                server_name.hostNames)
 
         SN = SNIExtension.ServerName
 

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -132,7 +132,7 @@ class TestTLSExtension(unittest.TestCase):
         ext = ext.create(0, bytearray(b'\x00\x00'))
 
         self.assertEqual("TLSExtension(extType=0, "\
-                "extData=bytearray(b'\\x00\\x00'), server_type=False)",
+                "extData=bytearray(b'\\x00\\x00'), serverType=False)",
                 repr(ext))
 
 class TestSNIExtension(unittest.TestCase):

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -159,7 +159,7 @@ class TestClientHello(unittest.TestCase):
             b'\x00'*2 +           # cipher suites length
             b'\x00' +             # compression methods length
             b'\x00\x07' +         # extensions length - 7 bytes
-            b'\x00\x09' +         # extension type - cert_types (9)
+            b'\x00\x09' +         # extension type - certTypes (9)
             b'\x00\x03' +         # extension length - 3 bytes
             b'\x02' +             # length of array - 2 bytes
             b'\x00' +             # type - x509 (0)
@@ -174,8 +174,8 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual([], client_hello.cipher_suites)
         self.assertEqual([], client_hello.compression_methods)
         self.assertEqual([0,1], client_hello.certificate_types)
-        cert_types = ClientCertTypeExtension().create([0,1])
-        self.assertEqual([cert_types], client_hello.extensions)
+        certTypes = ClientCertTypeExtension().create([0,1])
+        self.assertEqual([certTypes], client_hello.extensions)
 
     def test_parse_with_SRP_extension(self):
         p = Parser(bytearray(
@@ -461,7 +461,7 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual(client_hello.certificate_types, [0, 1, 2])
 
         ext = client_hello.getExtension(ExtensionType.cert_type)
-        self.assertEqual(ext.cert_types, [0, 1, 2])
+        self.assertEqual(ext.certTypes, [0, 1, 2])
 
     def test_srp_username(self):
         client_hello = ClientHello().create((3, 3), bytearray(1), bytearray(0),

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -1026,16 +1026,16 @@ class TestAlert(unittest.TestCase):
         self.assertEqual(alert.level, 0)
         self.assertEqual(alert.description, 0)
 
-    def test_level_name(self):
+    def test_levelName(self):
         alert = Alert().create(AlertDescription.record_overflow,
                 AlertLevel.fatal)
 
-        self.assertEqual("fatal", alert.level_name)
+        self.assertEqual("fatal", alert.levelName)
 
-    def test_level_name_with_wrong_level(self):
+    def test_levelName_with_wrong_level(self):
         alert = Alert().create(AlertDescription.close_notify, 11)
 
-        self.assertEqual("unknown(11)", alert.level_name)
+        self.assertEqual("unknown(11)", alert.levelName)
 
     def test_description_name(self):
         alert = Alert().create(AlertDescription.record_overflow,

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -407,7 +407,7 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual("client_hello,version(3.0),random(...),"\
                 "session ID(bytearray(b'')),cipher suites([]),"\
                 "compression methods([0]),extensions(["\
-                "TLSExtension(extType=0, ext_data=bytearray(b'\\x00'), "\
+                "TLSExtension(extType=0, extData=bytearray(b'\\x00'), "\
                 "server_type=False)])",
                 str(client_hello))
 
@@ -419,7 +419,7 @@ class TestClientHello(unittest.TestCase):
                 "random=bytearray(b'\\x00'), session_id=bytearray(b''), "\
                 "cipher_suites=[], compression_methods=[0], "\
                 "extensions=[TLSExtension(extType=0, "\
-                "ext_data=bytearray(b''), server_type=False)])",
+                "extData=bytearray(b''), server_type=False)])",
                 repr(client_hello))
 
     def test_getExtension(self):

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -547,7 +547,7 @@ class TestClientHello(unittest.TestCase):
         client_hello = ClientHello().create((3, 3), bytearray(1), bytearray(0),
                 [])
 
-        sni_ext = SNIExtension().create(server_names=[\
+        sni_ext = SNIExtension().create(serverNames=[\
                 SNIExtension.ServerName(1, b'test')])
 
         client_hello.extensions = [sni_ext]

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -408,7 +408,7 @@ class TestClientHello(unittest.TestCase):
                 "session ID(bytearray(b'')),cipher suites([]),"\
                 "compression methods([0]),extensions(["\
                 "TLSExtension(extType=0, extData=bytearray(b'\\x00'), "\
-                "server_type=False)])",
+                "serverType=False)])",
                 str(client_hello))
 
     def test___repr__(self):
@@ -419,7 +419,7 @@ class TestClientHello(unittest.TestCase):
                 "random=bytearray(b'\\x00'), session_id=bytearray(b''), "\
                 "cipher_suites=[], compression_methods=[0], "\
                 "extensions=[TLSExtension(extType=0, "\
-                "extData=bytearray(b''), server_type=False)])",
+                "extData=bytearray(b''), serverType=False)])",
                 repr(client_hello))
 
     def test_getExtension(self):

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -1037,16 +1037,16 @@ class TestAlert(unittest.TestCase):
 
         self.assertEqual("unknown(11)", alert.levelName)
 
-    def test_description_name(self):
+    def test_descriptionName(self):
         alert = Alert().create(AlertDescription.record_overflow,
                 AlertLevel.fatal)
 
-        self.assertEqual("record_overflow", alert.description_name)
+        self.assertEqual("record_overflow", alert.descriptionName)
 
-    def test_description_name_with_wrong_id(self):
+    def test_descriptionName_with_wrong_id(self):
         alert = Alert().create(1)
 
-        self.assertEqual("unknown(1)", alert.description_name)
+        self.assertEqual("unknown(1)", alert.descriptionName)
 
     def test___str__(self):
         alert = Alert().create(AlertDescription.record_overflow,

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -990,11 +990,11 @@ class TestRecordHeader3(unittest.TestCase):
         self.assertEqual((3, 3), rh.version)
         self.assertEqual(15, rh.length)
 
-    def test_type_name(self):
+    def test_typeName(self):
         rh = RecordHeader3()
         rh = rh.create((3,0), ContentType.application_data, 0)
 
-        self.assertEqual("application_data", rh.type_name)
+        self.assertEqual("application_data", rh.typeName)
 
     def test___str__(self):
         rh = RecordHeader3()

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -407,7 +407,7 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual("client_hello,version(3.0),random(...),"\
                 "session ID(bytearray(b'')),cipher suites([]),"\
                 "compression methods([0]),extensions(["\
-                "TLSExtension(ext_type=0, ext_data=bytearray(b'\\x00'), "\
+                "TLSExtension(extType=0, ext_data=bytearray(b'\\x00'), "\
                 "server_type=False)])",
                 str(client_hello))
 
@@ -418,7 +418,7 @@ class TestClientHello(unittest.TestCase):
         self.assertEqual("ClientHello(ssl2=False, client_version=(3.3), "\
                 "random=bytearray(b'\\x00'), session_id=bytearray(b''), "\
                 "cipher_suites=[], compression_methods=[0], "\
-                "extensions=[TLSExtension(ext_type=0, "\
+                "extensions=[TLSExtension(extType=0, "\
                 "ext_data=bytearray(b''), server_type=False)])",
                 repr(client_hello))
 


### PR DESCRIPTION
Since the majority of library uses camelCase for field names, fix the newly added ones (since v0.4.7) to use it too

no logic changes
