### PR TITLE
Implement TLS-PSK ciphersuites

### DIFF
--- a/scripts/pskdb.py
+++ b/scripts/pskdb.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+
+# Authors:
+#   Trevor Perrin
+#   Martin von Loewis - python 3 port
+#   Fiach Antaw - PskDB implementation
+#
+# See the LICENSE file for legal information regarding use of this file.
+
+from __future__ import print_function
+import sys
+import os
+import socket
+import math
+import binascii
+
+if __name__ != "__main__":
+    raise "This must be run as a command, not used as a module!"
+
+
+from tlslite import *
+from tlslite import __version__
+
+if len(sys.argv) == 1 or (len(sys.argv)==2 and sys.argv[1].lower().endswith("help")):
+    print("")
+    print("Version: %s" % __version__)
+    print("")
+    print("RNG: %s" % prngName)
+    print("")
+    print("Modules:")
+    if m2cryptoLoaded:
+        print("  M2Crypto    : Loaded")
+    else:
+        print("  M2Crypto    : Not Loaded")
+    if pycryptoLoaded:
+        print("  pycrypto    : Loaded")
+    else:
+        print("  pycrypto    : Not Loaded")
+    if gmpyLoaded:
+        print("  GMPY        : Loaded")
+    else:
+        print("  GMPY        : Not Loaded")
+    print("")
+    print("Commands:")
+    print("")
+    print("  createpsk       <db>")
+    print("")
+    print("  add    <db> <identity> <key>")
+    print("  del    <db> <identity>")
+    print("  list   <db>")
+    print("")
+    print("Keys must be provided as hex-encoded strings")
+    sys.exit()
+
+cmd = sys.argv[1].lower()
+
+class Args:
+    def __init__(self, argv):
+        self.argv = argv
+    def get(self, index):
+        if len(self.argv)<=index:
+            raise SyntaxError("Not enough arguments")
+        return self.argv[index]
+    def getLast(self, index):
+        if len(self.argv)>index+1:
+            raise SyntaxError("Too many arguments")
+        return self.get(index)
+
+args = Args(sys.argv)
+
+def reformatDocString(s):
+    lines = s.splitlines()
+    newLines = []
+    for line in lines:
+        newLines.append("  " + line.strip())
+    return "\n".join(newLines)
+
+try:
+    if cmd == "help":
+        command = args.getLast(2).lower()
+        if command == "valid":
+            print("")
+        else:
+            print("Bad command: '%s'" % command)
+
+    elif cmd == "createpsk":
+        dbName = args.get(2)
+
+        db = PskDB(dbName)
+        db.create()
+
+    elif cmd == "add":
+        dbName = args.get(2)
+        identity = args.get(3)
+        key = binascii.unhexlify(args.get(4))
+
+        db = PskDB(dbName)
+        db.open()
+        if identity in db:
+            print("PSK Identity already in database!")
+            sys.exit()
+        db[identity] = key
+
+    elif cmd == "del":
+        dbName = args.get(2)
+        identity = args.getLast(3)
+        db = PskDB(dbName)
+        db.open()
+        del(db[identity])
+
+    elif cmd == "list":
+        dbName = args.get(2)
+        db = PskDB(dbName)
+        db.open()
+
+        print("PSK Database")
+        for identity in db.keys():
+            key = db[identity]
+            print(identity, binascii.hexlify(key))
+    else:
+        print("Bad command: '%s'" % cmd)
+except:
+    raise

--- a/tlslite/api.py
+++ b/tlslite/api.py
@@ -10,6 +10,7 @@ from .session import Session
 from .sessioncache import SessionCache
 from .tlsconnection import TLSConnection
 from .verifierdb import VerifierDB
+from .pskdb import PskDB
 from .x509 import X509
 from .x509certchain import X509CertChain
 

--- a/tlslite/constants.py
+++ b/tlslite/constants.py
@@ -5,6 +5,7 @@
 #   Dimitris Moraitis - Anon ciphersuites
 #   Dave Baggett (Arcode Corporation) - canonicalCipherName
 #   Yngve Pettersen (ported by Paul Sokolovsky) - TLS 1.2
+#   Fiach Antaw - TLS-PSK ciphersuites
 #
 # See the LICENSE file for legal information regarding use of this file.
 
@@ -142,6 +143,21 @@ class CipherSuite:
     TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA = 0xC01E
     TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA = 0xC021
 
+    TLS_PSK_WITH_RC4_128_SHA = 0x008A
+    TLS_PSK_WITH_3DES_EDE_CBC_SHA = 0x008B
+    TLS_PSK_WITH_AES_128_CBC_SHA = 0x008C
+    TLS_PSK_WITH_AES_256_CBC_SHA = 0x008D
+
+    TLS_DHE_PSK_WITH_RC4_128_SHA = 0x008E
+    TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA = 0x008F
+    TLS_DHE_PSK_WITH_AES_128_CBC_SHA = 0x0090
+    TLS_DHE_PSK_WITH_AES_256_CBC_SHA = 0x0091
+
+    TLS_RSA_PSK_WITH_RC4_128_SHA = 0x0092
+    TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA = 0x0093
+    TLS_RSA_PSK_WITH_AES_128_CBC_SHA = 0x0094
+    TLS_RSA_PSK_WITH_AES_256_CBC_SHA = 0x0095
+
 
     TLS_RSA_WITH_3DES_EDE_CBC_SHA = 0x000A
     TLS_RSA_WITH_AES_128_CBC_SHA = 0x002F
@@ -159,11 +175,17 @@ class CipherSuite:
     tripleDESSuites = []
     tripleDESSuites.append(TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA)
     tripleDESSuites.append(TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA)
+    tripleDESSuites.append(TLS_PSK_WITH_3DES_EDE_CBC_SHA)
+    tripleDESSuites.append(TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA)
+    tripleDESSuites.append(TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA)
     tripleDESSuites.append(TLS_RSA_WITH_3DES_EDE_CBC_SHA)
 
     aes128Suites = []
     aes128Suites.append(TLS_SRP_SHA_WITH_AES_128_CBC_SHA)
     aes128Suites.append(TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA)
+    aes128Suites.append(TLS_PSK_WITH_AES_128_CBC_SHA)
+    aes128Suites.append(TLS_DHE_PSK_WITH_AES_128_CBC_SHA)
+    aes128Suites.append(TLS_RSA_PSK_WITH_AES_128_CBC_SHA)
     aes128Suites.append(TLS_RSA_WITH_AES_128_CBC_SHA)
     aes128Suites.append(TLS_DH_ANON_WITH_AES_128_CBC_SHA)
     aes128Suites.append(TLS_RSA_WITH_AES_128_CBC_SHA256)
@@ -171,6 +193,9 @@ class CipherSuite:
     aes256Suites = []
     aes256Suites.append(TLS_SRP_SHA_WITH_AES_256_CBC_SHA)
     aes256Suites.append(TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA)
+    aes256Suites.append(TLS_PSK_WITH_AES_256_CBC_SHA)
+    aes256Suites.append(TLS_DHE_PSK_WITH_AES_256_CBC_SHA)
+    aes256Suites.append(TLS_RSA_PSK_WITH_AES_256_CBC_SHA)
     aes256Suites.append(TLS_RSA_WITH_AES_256_CBC_SHA)
     aes256Suites.append(TLS_DH_ANON_WITH_AES_256_CBC_SHA)
     aes256Suites.append(TLS_RSA_WITH_AES_256_CBC_SHA256)
@@ -178,6 +203,9 @@ class CipherSuite:
     rc4Suites = []
     rc4Suites.append(TLS_RSA_WITH_RC4_128_SHA)
     rc4Suites.append(TLS_RSA_WITH_RC4_128_MD5)
+    rc4Suites.append(TLS_PSK_WITH_RC4_128_SHA)
+    rc4Suites.append(TLS_DHE_PSK_WITH_RC4_128_SHA)
+    rc4Suites.append(TLS_RSA_PSK_WITH_RC4_128_SHA)
     
     shaSuites = []
     shaSuites.append(TLS_SRP_SHA_WITH_3DES_EDE_CBC_SHA)
@@ -186,6 +214,18 @@ class CipherSuite:
     shaSuites.append(TLS_SRP_SHA_RSA_WITH_3DES_EDE_CBC_SHA)
     shaSuites.append(TLS_SRP_SHA_RSA_WITH_AES_128_CBC_SHA)
     shaSuites.append(TLS_SRP_SHA_RSA_WITH_AES_256_CBC_SHA)
+    shaSuites.append(TLS_PSK_WITH_RC4_128_SHA)
+    shaSuites.append(TLS_PSK_WITH_3DES_EDE_CBC_SHA)
+    shaSuites.append(TLS_PSK_WITH_AES_128_CBC_SHA)
+    shaSuites.append(TLS_PSK_WITH_AES_256_CBC_SHA)
+    shaSuites.append(TLS_DHE_PSK_WITH_RC4_128_SHA)
+    shaSuites.append(TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA)
+    shaSuites.append(TLS_DHE_PSK_WITH_AES_128_CBC_SHA)
+    shaSuites.append(TLS_DHE_PSK_WITH_AES_256_CBC_SHA)
+    shaSuites.append(TLS_RSA_PSK_WITH_RC4_128_SHA)
+    shaSuites.append(TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA)
+    shaSuites.append(TLS_RSA_PSK_WITH_AES_128_CBC_SHA)
+    shaSuites.append(TLS_RSA_PSK_WITH_AES_256_CBC_SHA)
     shaSuites.append(TLS_RSA_WITH_3DES_EDE_CBC_SHA)
     shaSuites.append(TLS_RSA_WITH_AES_128_CBC_SHA)
     shaSuites.append(TLS_RSA_WITH_AES_256_CBC_SHA)
@@ -257,6 +297,42 @@ class CipherSuite:
     def getSrpAllSuites(settings):
         return CipherSuite._filterSuites(CipherSuite.srpAllSuites, settings)
 
+    pskSuites = []
+    pskSuites.append(TLS_PSK_WITH_RC4_128_SHA)
+    pskSuites.append(TLS_PSK_WITH_3DES_EDE_CBC_SHA)
+    pskSuites.append(TLS_PSK_WITH_AES_128_CBC_SHA)
+    pskSuites.append(TLS_PSK_WITH_AES_256_CBC_SHA)
+
+    @staticmethod
+    def getPskSuites(settings):
+        return CipherSuite._filterSuites(CipherSuite.pskSuites, settings)
+
+    pskDHSuites = []
+    pskDHSuites.append(TLS_DHE_PSK_WITH_RC4_128_SHA)
+    pskDHSuites.append(TLS_DHE_PSK_WITH_3DES_EDE_CBC_SHA)
+    pskDHSuites.append(TLS_DHE_PSK_WITH_AES_128_CBC_SHA)
+    pskDHSuites.append(TLS_DHE_PSK_WITH_AES_256_CBC_SHA)
+
+    @staticmethod
+    def getPskDHSuites(settings):
+        return CipherSuite._filterSuites(CipherSuite.pskDHSuites, settings)
+
+    pskCertSuites = []
+    pskCertSuites.append(TLS_RSA_PSK_WITH_RC4_128_SHA)
+    pskCertSuites.append(TLS_RSA_PSK_WITH_3DES_EDE_CBC_SHA)
+    pskCertSuites.append(TLS_RSA_PSK_WITH_AES_128_CBC_SHA)
+    pskCertSuites.append(TLS_RSA_PSK_WITH_AES_256_CBC_SHA)
+
+    @staticmethod
+    def getPskCertSuites(settings):
+        return CipherSuite._filterSuites(CipherSuite.pskCertSuites, settings)
+
+    pskAllSuites = pskSuites + pskDHSuites + pskCertSuites
+
+    @staticmethod
+    def getPskAllSuites(settings):
+        return CipherSuite._filterSuites(CipherSuite.pskAllSuites, settings)
+
     certSuites = []
     certSuites.append(TLS_RSA_WITH_AES_256_CBC_SHA256)
     certSuites.append(TLS_RSA_WITH_AES_128_CBC_SHA256)
@@ -265,7 +341,7 @@ class CipherSuite:
     certSuites.append(TLS_RSA_WITH_3DES_EDE_CBC_SHA)
     certSuites.append(TLS_RSA_WITH_RC4_128_SHA)
     certSuites.append(TLS_RSA_WITH_RC4_128_MD5)
-    certAllSuites = srpCertSuites + certSuites
+    certAllSuites = srpCertSuites + pskCertSuites + certSuites
     
     @staticmethod
     def getCertSuites(settings):
@@ -316,6 +392,10 @@ class Fault:
     badVerifyMessage = 601
     clientCertFaults = list(range(601,602))
 
+    badIdentity = 701
+    badPSK = 702
+    clientPskFaults = list(range(701,702))
+
     badPremasterPadding = 501
     shortPremasterSecret = 502
     clientNoAuthFaults = list(range(501,503))
@@ -338,6 +418,9 @@ class Fault:
         badPremasterPadding: (AlertDescription.bad_record_mac,),\
         shortPremasterSecret: (AlertDescription.bad_record_mac,),\
         badVerifyMessage: (AlertDescription.decrypt_error,),\
+        badIdentity: (AlertDescription.unknown_psk_identity,\
+                      AlertDescription.decrypt_error),\
+        badPSK: (AlertDescription.decrypt_error,),\
         badFinished: (AlertDescription.decrypt_error,),\
         badMAC: (AlertDescription.bad_record_mac,),\
         badPadding: (AlertDescription.bad_record_mac,),\
@@ -353,6 +436,8 @@ class Fault:
         shortPremasterSecret: "short premaster secret",\
         badVerifyMessage: "bad verify message",\
         badFinished: "bad finished message",\
+        badIdentity: "bad PSK identity",\
+        badPSK: "bad PSK",\
         badMAC: "bad MAC",\
         badPadding: "bad padding",\
         ignoreVersionForCipher: "ignore version for cipher"

--- a/tlslite/pskdb.py
+++ b/tlslite/pskdb.py
@@ -1,0 +1,54 @@
+# Author: Fiach Antaw
+# See the LICENSE file for legal information regarding use of this file.
+
+"""Class for storing PSK identity/key pairs."""
+
+from .utils.cryptomath import *
+from .utils.compat import *
+from tlslite import mathtls
+from .basedb import BaseDB
+
+class PskDB(BaseDB):
+    """This class represent an in-memory or on-disk database of PSK
+    identity/key pairs.
+
+    A PskDB can be passed to a client or server handshake to authenticate
+    the other party based on one of the key pairs.
+
+    This class is thread-safe.
+    """
+    def __init__(self, filename=None):
+        """Create a new PskDB instance.
+
+        @type filename: str
+        @param filename: Filename for an on-disk database, or None for
+        an in-memory database.  If the filename already exists, follow
+        this with a call to open().  To create a new on-disk database,
+        follow this with a call to create().
+        """
+        BaseDB.__init__(self, filename, "psk")
+
+    def _getItem(self, identity, valueStr):
+        return valueStr
+
+    def __setitem__(self, identity, psk):
+        """Add a PSK identity/key pair to the database.
+
+        @type identity: str
+        @param identity: The PSK identity to associate the key with.
+        Must be less than 256 characters in length.  Must not already
+        be in the database.
+
+        @type psk: bytes
+        @param psk: The pre-shared key to add.
+        """
+        BaseDB.__setitem__(self, identity, psk)
+
+
+    def _setItem(self, identity, psk):
+        if len(identity)>=256:
+            raise ValueError("username too long")
+        return psk
+
+    def _checkItem(self, value, identity, psk):
+        return value == psk


### PR DESCRIPTION
This PR implements the TLS-PSK ciphersuites as defined in RFC4279.
- One new API has been added, `handshakeClientPSK`, which accepts a callback function returning the PSK identity and PSK based on an (optional) server-provided identity hint. A callback is used because the format of the identity hint is not specified in the RFC; this is consistent with the API exposed by OpenSSL. A typical example of a PSK identity hint might be a comma-separated list of all the PSK identities recognized by the server.
- A `PskDB` class has been added, associating PSK identities with PSKs in a manner similar to VerifierDB
- The `handshakeServer` API has been extended with the addition of a `pskDB` parameter (accepting a `PskDB` database) and a `pskIdentityHint` parameter (sent to the client during key exchange, if present).
- A pskdb.py script has been added, allowing `PskDB` files to be created and edited.
- The tls.py script has been extended to support TLS-PSK ciphersuites.
- Test-cases for the TLS-PSK ciphersuites have been added (though 'make test' currently fails due to #107).
