### PR TITLE
Fixed generator functions (next) to work with python 3.

### DIFF
--- a/tlslite/integration/asyncstatemachine.py
+++ b/tlslite/integration/asyncstatemachine.py
@@ -157,7 +157,7 @@ class AsyncStateMachine:
 
     def _doHandshakeOp(self):
         try:
-            self.result = self.handshaker.next()
+            self.result = next(self.handshaker)
         except StopIteration:
             self.handshaker = None
             self.result = None
@@ -165,14 +165,14 @@ class AsyncStateMachine:
 
     def _doCloseOp(self):
         try:
-            self.result = self.closer.next()
+            self.result = next(self.closer)
         except StopIteration:
             self.closer = None
             self.result = None
             self.outCloseEvent()
 
     def _doReadOp(self):
-        self.result = self.reader.next()
+        self.result = next(self.reader)
         if not self.result in (0,1):
             readBuffer = self.result
             self.reader = None
@@ -181,7 +181,7 @@ class AsyncStateMachine:
 
     def _doWriteOp(self):
         try:
-            self.result = self.writer.next()
+            self.result = next(self.writer)
         except StopIteration:
             self.writer = None
             self.result = None


### PR DESCRIPTION
This patch fixes these methods which use generators.  The next method is no longer defined in python 3 but is a built in function.
