### PR TITLE
docs: Fix a few typos

### DIFF
--- a/tlslite/__init__.py
+++ b/tlslite/__init__.py
@@ -4,7 +4,7 @@
 """TLS Lite is a free python library that implements SSL and TLS. TLS Lite
 supports RSA and SRP ciphersuites. TLS Lite is pure python, however it can use
 other libraries for faster crypto operations. TLS Lite integrates with several
-stdlib neworking libraries.
+stdlib networking libraries.
 
 API documentation is available in the 'docs' directory.
 

--- a/tlslite/extensions.py
+++ b/tlslite/extensions.py
@@ -226,7 +226,7 @@ class SNIExtension(TLSExtension):
 
         Any of the parameters may be None, in that case the list inside the
         extension won't be defined, if either hostNames or serverNames is
-        an empty list, then the extension will define a list of lenght 0.
+        an empty list, then the extension will define a list of length 0.
 
         If multiple parameters are specified at the same time, then the
         resulting list of names will be concatenated in order of hostname,
@@ -608,7 +608,7 @@ class SRPExtension(TLSExtension):
         @param identity: UTF-8 encoded identity (user name) to be provided
             to user. MUST be shorter than 2^8-1.
 
-        @raise ValueError: when the identity lenght is longer than 2^8-1
+        @raise ValueError: when the identity length is longer than 2^8-1
         """
 
         if identity is None:
@@ -747,7 +747,7 @@ class TACKExtension(TLSExtension):
 
         def __repr__(self):
             """
-            Return programmmer readable representation of TACK object
+            Return programmer readable representation of TACK object
 
             @rtype: str
             """
@@ -883,7 +883,7 @@ class TACKExtension(TLSExtension):
 
     def create(self, tacks, activation_flags):
         """
-        Initialize the insance of TACKExtension
+        Initialize the instance of TACKExtension
 
         @rtype: TACKExtension
         """

--- a/tlslite/messages.py
+++ b/tlslite/messages.py
@@ -704,7 +704,7 @@ class ServerHello(HandshakeMsg):
         if val is None:
             return
         else:
-        # convinience function, make sure the values are properly encoded
+        # convenience function, make sure the values are properly encoded
             val = [ bytearray(x) for x in val ]
 
         npn_ext = self.getExtension(ExtensionType.supports_npn)

--- a/tlslite/tlsconnection.py
+++ b/tlslite/tlsconnection.py
@@ -97,7 +97,7 @@ class TLSConnection(TLSRecordLayer):
         @type checker: L{tlslite.Checker.Checker}
         @param checker: A Checker instance.  This instance will be
         invoked to examine the other party's authentication
-        credentials, if the handshake completes succesfully.
+        credentials, if the handshake completes successfully.
         
         @type serverName: string
         @param serverName: The ServerNameIndication TLS Extension.
@@ -170,7 +170,7 @@ class TLSConnection(TLSRecordLayer):
         @type checker: L{tlslite.checker.Checker}
         @param checker: A Checker instance.  This instance will be
         invoked to examine the other party's authentication
-        credentials, if the handshake completes succesfully.
+        credentials, if the handshake completes successfully.
 
         @type reqTack: bool
         @param reqTack: Whether or not to send a "tack" TLS Extension, 
@@ -260,7 +260,7 @@ class TLSConnection(TLSRecordLayer):
         @type checker: L{tlslite.checker.Checker}
         @param checker: A Checker instance.  This instance will be
         invoked to examine the other party's authentication
-        credentials, if the handshake completes succesfully.
+        credentials, if the handshake completes successfully.
         
         @type nextProtos: list of strings.
         @param nextProtos: A list of upper layer protocols ordered by
@@ -1051,7 +1051,7 @@ class TLSConnection(TLSRecordLayer):
         @type checker: L{tlslite.checker.Checker}
         @param checker: A Checker instance.  This instance will be
         invoked to examine the other party's authentication
-        credentials, if the handshake completes succesfully.
+        credentials, if the handshake completes successfully.
         
         @type reqCAs: list of L{bytearray} of unsigned bytes
         @param reqCAs: A collection of DER-encoded DistinguishedNames that

--- a/unit_tests/test_tlslite_extensions.py
+++ b/unit_tests/test_tlslite_extensions.py
@@ -260,13 +260,13 @@ class TestSNIExtension(unittest.TestCase):
             bytearray(b'example.org')])
 
         self.assertEqual(bytearray(
-            b'\x00\x1c' +   # lenght of array - 28 bytes
+            b'\x00\x1c' +   # length of array - 28 bytes
             b'\x00' +       # type of element - host_name (0)
             b'\x00\x0b' +   # length of element - 11 bytes
             # utf-8 encoding of example.com
             b'\x65\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d' +
-            b'\x00' +       # type of elemnt - host_name (0)
-            b'\x00\x0b' +   # length of elemnet - 11 bytes
+            b'\x00' +       # type of element - host_name (0)
+            b'\x00\x0b' +   # length of element - 11 bytes
             # utf-8 encoding of example.org
             b'\x65\x78\x61\x6d\x70\x6c\x65\x2e\x6f\x72\x67'
             ), server_name.extData)
@@ -274,13 +274,13 @@ class TestSNIExtension(unittest.TestCase):
         self.assertEqual(bytearray(
             b'\x00\x00' +   # type of extension - SNI (0)
             b'\x00\x1e' +   # length of extension - 26 bytes
-            b'\x00\x1c' +   # lenght of array - 24 bytes
+            b'\x00\x1c' +   # length of array - 24 bytes
             b'\x00' +       # type of element - host_name (0)
             b'\x00\x0b' +   # length of element - 11 bytes
             # utf-8 encoding of example.com
             b'\x65\x78\x61\x6d\x70\x6c\x65\x2e\x63\x6f\x6d' +
-            b'\x00' +       # type of elemnt - host_name (0)
-            b'\x00\x0b' +   # length of elemnet - 11 bytes
+            b'\x00' +       # type of element - host_name (0)
+            b'\x00\x0b' +   # length of element - 11 bytes
             # utf-8 encoding of example.org
             b'\x65\x78\x61\x6d\x70\x6c\x65\x2e\x6f\x72\x67'
             ), server_name.write())

--- a/unit_tests/test_tlslite_messages.py
+++ b/unit_tests/test_tlslite_messages.py
@@ -163,7 +163,7 @@ class TestClientHello(unittest.TestCase):
             b'\x00\x03' +         # extension length - 3 bytes
             b'\x02' +             # length of array - 2 bytes
             b'\x00' +             # type - x509 (0)
-            b'\x01'               # type - opengpg (1)
+            b'\x01'               # type - openpgp (1)
             ))
         client_hello = ClientHello()
         client_hello = client_hello.parse(p)
@@ -562,7 +562,7 @@ class TestClientHello(unittest.TestCase):
             b'\x00\x02' +           # version - SSLv2
             b'\x00\x15' +           # cipher spec length - 21 bytes
             b'\x00\x00' +           # session ID length - 0 bytes
-            b'\x00\x10' +           # challange length - 16 bytes
+            b'\x00\x10' +           # challenge length - 16 bytes
             b'\x07\x00\xc0' +       # cipher - SSL2_DES_192_EDE3_CBC_WITH_MD5
             b'\x05\x00\x80' +       # cipher - SSL2_IDEA_128_CBC_WITH_MD5
             b'\x03\x00\x80' +       # cipher - SSL2_RC2_CBC_128_CBC_WITH_MD5
@@ -849,7 +849,7 @@ class TestServerHello(unittest.TestCase):
             # utf-8 encoding of 'spdy/3'
             b'\x73\x70\x64\x79\x2f\x33'
             b'\x08' +               # second entry length - 8 bytes
-            # utf-8 endoding of 'http/1.1'
+            # utf-8 encoding of 'http/1.1'
             b'\x68\x74\x74\x70\x2f\x31\x2e\x31'
             )), list(server_hello.write()))
 


### PR DESCRIPTION
There are small typos in:
- tlslite/__init__.py
- tlslite/extensions.py
- tlslite/messages.py
- tlslite/tlsconnection.py
- unit_tests/test_tlslite_extensions.py
- unit_tests/test_tlslite_messages.py

Fixes:
- Should read `length` rather than `lenght`.
- Should read `successfully` rather than `succesfully`.
- Should read `element` rather than `elemnt`.
- Should read `element` rather than `elemnet`.
- Should read `programmer` rather than `programmmer`.
- Should read `networking` rather than `neworking`.
- Should read `instance` rather than `insance`.
- Should read `encoding` rather than `endoding`.
- Should read `convenience` rather than `convinience`.
- Should read `challenge` rather than `challange`.
- Should read `openpgp` rather than `opengpg`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md